### PR TITLE
capistrano: use settings.properties from shared_configs

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -22,10 +22,10 @@ set :deploy_to, "/opt/app/#{fetch(:user)}/#{fetch(:application)}"
 # set :pty, true
 
 # Default value for :linked_files is []
-# append :linked_files, 'config/settings.yml'
+append :linked_files, 'config/settings.properties'
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w{build .gradle}
+set :linked_dirs, %w{build config .gradle}
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -2,5 +2,7 @@
 set :deploy_host, "was-downloader-dev.stanford.edu"
 server fetch(:deploy_host), user: fetch(:user), roles: 'app'
 
+set :bundle_without, 'deployment'
+
 # allow ssh to host
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -2,5 +2,7 @@
 set :deploy_host, "was-downloader.stanford.edu"
 server fetch(:deploy_host), user: fetch(:user), roles: 'app'
 
+set :bundle_without, 'deployment'
+
 # allow ssh to host
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,5 +2,7 @@
 set :deploy_host, "was-downloader-stage.stanford.edu"
 server fetch(:deploy_host), user: fetch(:user), roles: 'app'
 
+set :bundle_without, 'deployment'
+
 # allow ssh to host
 Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
last part of #25 (which I forgot)

connects to #25 

Note that existing `config/settings.properties` is used by tests, but the file upon deployment is the one from shared_configs.  (Yay)