### PR TITLE
args override settings; add setting for output directory

### DIFF
--- a/config/settings.properties
+++ b/config/settings.properties
@@ -8,4 +8,4 @@ username=user
 password=pass
 
 # Destination directory for downloaded WARC files
-outputDir=/var/downloadedWarcFiles
+outputBaseDir=/var/downloadedWarcFiles

--- a/config/settings.properties
+++ b/config/settings.properties
@@ -6,3 +6,6 @@ username=user
 
 # Password for our account
 password=pass
+
+# Destination directory for downloaded WARC files
+outputDir=/var/downloadedWarcFiles

--- a/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
@@ -99,7 +99,8 @@ public class WasapiDownloaderSettings {
     int width = HelpFormatter.DEFAULT_WIDTH;
     int leftPad = HelpFormatter.DEFAULT_LEFT_PAD;
     int descPad = HelpFormatter.DEFAULT_DESC_PAD;
-    helpFormatter.printHelp(pw, width, "bin/wasapi-downloader", "=====\npossible arguments\n---", wdsOpts, leftPad, descPad, "=====", true);
+    String helpMsgHeader = "=====\nallowed arguments\n(may also also be specified in config/settings.properties, sans leading hyphens)\n---";
+    helpFormatter.printHelp(pw, width, "bin/wasapi-downloader", helpMsgHeader, wdsOpts, leftPad, descPad, "=====", true);
     pw.flush();
     sw.flush();
     return sw.getBuffer();
@@ -108,7 +109,7 @@ public class WasapiDownloaderSettings {
   private CharSequence getSettingsSummaryCharSeq() {
     StringBuilder buf = new StringBuilder();
     buf.append("=====\n");
-    buf.append("current settings\n");
+    buf.append("current settings (arg values override settings.properties values)\n");
     buf.append("---\n");
     for (String settingName : settings.stringPropertyNames()) {
       if (!settingName.equals(PASSWORD_PARAM_NAME)) {
@@ -133,6 +134,9 @@ public class WasapiDownloaderSettings {
   @SuppressWarnings("checkstyle:linelength")
   private void setupArgOptions() {
     Option helpOpt = Option.builder("h").longOpt(HELP_PARAM_NAME).desc("print this message (which describes expected arguments and dumps current config)").build();
+    Option baseUrlOpt = buildArgOption(BASE_URL_PARAM_NAME, "the base URL of the WASAPI server from which to pull WARC files");
+    Option usernameOpt = buildArgOption(USERNAME_PARAM_NAME, "the username for WASAPI server login");
+    Option passwordOpt = buildArgOption(PASSWORD_PARAM_NAME, "the password for WASAPI server login");
     Option collectionIdOpt = buildArgOption(COLLECTION_ID_PARAM_NAME, "a collection from which to download crawl files");
     Option jobIdOpt = buildArgOption(JOB_ID_PARAM_NAME, "a job from which to download crawl files");
     Option crawlStartAfterOpt = buildArgOption(CRAWL_START_AFTER_PARAM_NAME, "only download crawl files created after this date");
@@ -140,6 +144,9 @@ public class WasapiDownloaderSettings {
 
     wdsOpts = new Options();
     wdsOpts.addOption(helpOpt);
+    wdsOpts.addOption(baseUrlOpt);
+    wdsOpts.addOption(usernameOpt);
+    wdsOpts.addOption(passwordOpt);
     wdsOpts.addOption(collectionIdOpt);
     wdsOpts.addOption(jobIdOpt);
     wdsOpts.addOption(crawlStartAfterOpt);

--- a/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
@@ -17,6 +17,11 @@ import org.apache.commons.cli.ParseException;
 
 @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class WasapiDownloaderSettings {
+  // to add a new setting:
+  // * add a String constant for the setting/arg name
+  // * add a corresponding Option entry in optList
+  // * add an accessor method (preferably with a name corresponding to the setting name)
+  // * add to the tests to make sure it shows up in the usage info and settings dump
   public static final String BASE_URL_PARAM_NAME = "baseurl";
   public static final String USERNAME_PARAM_NAME = "username";
   public static final String PASSWORD_PARAM_NAME = "password";
@@ -25,17 +30,35 @@ public class WasapiDownloaderSettings {
   public static final String JOB_ID_PARAM_NAME = "jobId";
   public static final String CRAWL_START_AFTER_PARAM_NAME = "crawlStartAfter";
   public static final String CRAWL_START_BEFORE_PARAM_NAME = "crawlStartBefore";
-  public static final String OUTPUT_DIR_PARAM_NAME = "outputDir";
+  public static final String OUTPUT_BASE_DIR_PARAM_NAME = "outputBaseDir";
 
   private HelpFormatter helpFormatter;
-  private Options wdsOpts;
+  private static Options wdsOpts;
   private Properties settings;
   private String helpAndSettingsMessage;
+
+  private static Option[] optList = {
+    Option.builder("h").longOpt(HELP_PARAM_NAME).desc("print this message (which describes expected arguments and dumps current config)").build(),
+    buildArgOption(BASE_URL_PARAM_NAME, "the base URL of the WASAPI server from which to pull WARC files"),
+    buildArgOption(USERNAME_PARAM_NAME, "the username for WASAPI server login"),
+    buildArgOption(PASSWORD_PARAM_NAME, "the password for WASAPI server login"),
+    buildArgOption(COLLECTION_ID_PARAM_NAME, "a collection from which to download crawl files"),
+    buildArgOption(JOB_ID_PARAM_NAME, "a job from which to download crawl files"),
+    buildArgOption(CRAWL_START_AFTER_PARAM_NAME, "only download crawl files created after this date"),
+    buildArgOption(CRAWL_START_BEFORE_PARAM_NAME, "only download crawl files created before this date"),
+    buildArgOption(OUTPUT_BASE_DIR_PARAM_NAME, "destination directory for downloaded WARC files")
+  };
+
+  static {
+    wdsOpts = new Options();
+    for (Option opt : optList) {
+      wdsOpts.addOption(opt);
+    }
+  }
 
   public WasapiDownloaderSettings(String settingsFileLocation, String[] args) throws SettingsLoadException {
     try {
       loadPropertiesFile(settingsFileLocation);
-      setupArgOptions();
       parseArgsIntoSettings(args);
 
       //TODO: validate settings state.  see https://github.com/sul-dlss/wasapi-downloader/issues/42
@@ -81,8 +104,8 @@ public class WasapiDownloaderSettings {
     return settings.getProperty(CRAWL_START_BEFORE_PARAM_NAME);
   }
 
-  public String outputDir() {
-    return settings.getProperty(OUTPUT_DIR_PARAM_NAME);
+  public String outputBaseDir() {
+    return settings.getProperty(OUTPUT_BASE_DIR_PARAM_NAME);
   }
 
   public String getHelpAndSettingsMessage() {
@@ -134,30 +157,6 @@ public class WasapiDownloaderSettings {
 
   private static Option buildArgOption(String optionName, String description) {
     return Option.builder().hasArg().longOpt(optionName).desc(description).build();
-  }
-
-  @SuppressWarnings("checkstyle:linelength")
-  private void setupArgOptions() {
-    Option helpOpt = Option.builder("h").longOpt(HELP_PARAM_NAME).desc("print this message (which describes expected arguments and dumps current config)").build();
-    Option baseUrlOpt = buildArgOption(BASE_URL_PARAM_NAME, "the base URL of the WASAPI server from which to pull WARC files");
-    Option usernameOpt = buildArgOption(USERNAME_PARAM_NAME, "the username for WASAPI server login");
-    Option passwordOpt = buildArgOption(PASSWORD_PARAM_NAME, "the password for WASAPI server login");
-    Option collectionIdOpt = buildArgOption(COLLECTION_ID_PARAM_NAME, "a collection from which to download crawl files");
-    Option jobIdOpt = buildArgOption(JOB_ID_PARAM_NAME, "a job from which to download crawl files");
-    Option crawlStartAfterOpt = buildArgOption(CRAWL_START_AFTER_PARAM_NAME, "only download crawl files created after this date");
-    Option crawlStartBeforeOpt = buildArgOption(CRAWL_START_BEFORE_PARAM_NAME, "only download crawl files created before this date");
-    Option outputDirOpt = buildArgOption(OUTPUT_DIR_PARAM_NAME, "destination directory for downloaded WARC files");
-
-    wdsOpts = new Options();
-    wdsOpts.addOption(helpOpt);
-    wdsOpts.addOption(baseUrlOpt);
-    wdsOpts.addOption(usernameOpt);
-    wdsOpts.addOption(passwordOpt);
-    wdsOpts.addOption(collectionIdOpt);
-    wdsOpts.addOption(jobIdOpt);
-    wdsOpts.addOption(crawlStartAfterOpt);
-    wdsOpts.addOption(crawlStartBeforeOpt);
-    wdsOpts.addOption(outputDirOpt);
   }
 
   private void addParsedArgsToSettings(CommandLine parsedArgs) {

--- a/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
@@ -25,6 +25,7 @@ public class WasapiDownloaderSettings {
   public static final String JOB_ID_PARAM_NAME = "jobId";
   public static final String CRAWL_START_AFTER_PARAM_NAME = "crawlStartAfter";
   public static final String CRAWL_START_BEFORE_PARAM_NAME = "crawlStartBefore";
+  public static final String OUTPUT_DIR_PARAM_NAME = "outputDir";
 
   private HelpFormatter helpFormatter;
   private Options wdsOpts;
@@ -78,6 +79,10 @@ public class WasapiDownloaderSettings {
   // e.g. 2014-01-01, see https://github.com/WASAPI-Community/data-transfer-apis/tree/master/ait-reference-specification#paths--examples
   public String crawlStartBefore() {
     return settings.getProperty(CRAWL_START_BEFORE_PARAM_NAME);
+  }
+
+  public String outputDir() {
+    return settings.getProperty(OUTPUT_DIR_PARAM_NAME);
   }
 
   public String getHelpAndSettingsMessage() {
@@ -141,6 +146,7 @@ public class WasapiDownloaderSettings {
     Option jobIdOpt = buildArgOption(JOB_ID_PARAM_NAME, "a job from which to download crawl files");
     Option crawlStartAfterOpt = buildArgOption(CRAWL_START_AFTER_PARAM_NAME, "only download crawl files created after this date");
     Option crawlStartBeforeOpt = buildArgOption(CRAWL_START_BEFORE_PARAM_NAME, "only download crawl files created before this date");
+    Option outputDirOpt = buildArgOption(OUTPUT_DIR_PARAM_NAME, "destination directory for downloaded WARC files");
 
     wdsOpts = new Options();
     wdsOpts.addOption(helpOpt);
@@ -151,6 +157,7 @@ public class WasapiDownloaderSettings {
     wdsOpts.addOption(jobIdOpt);
     wdsOpts.addOption(crawlStartAfterOpt);
     wdsOpts.addOption(crawlStartBeforeOpt);
+    wdsOpts.addOption(outputDirOpt);
   }
 
   private void addParsedArgsToSettings(CommandLine parsedArgs) {

--- a/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
@@ -24,6 +24,7 @@ public class TestWasapiDownloaderSettings {
     assertEquals("baseurl value should have come from settings file", settings.baseUrlString(), "http://example.org");
     assertEquals("username value should have come from settings file", settings.username(), "user");
     assertEquals("password value should have come from settings file", settings.password(), "pass");
+    assertEquals("outputDir value should have come from settings file", settings.outputDir(), "/var/downloadedWarcFiles");
     assertEquals("collectionId value should have come from args", settings.collectionId(), "123");
     assertEquals("jobId value should have come from args", settings.jobId(), "456");
     assertEquals("crawlStartAfter value should have come from args", settings.crawlStartAfter(), "2014-03-14");
@@ -61,9 +62,10 @@ public class TestWasapiDownloaderSettings {
 
   @Test
   public void argsOverrideSettings() throws SettingsLoadException {
-    String[] args = { "--username=user2" };
+    String[] args = { "--username=user2", "--outputDir=/tmp/warcDownloads" };
     WasapiDownloaderSettings settings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, args);
     assertEquals("the username from the .properties file should get overridden by the command-line arg", settings.username(), "user2");
+    assertEquals("the outputDir from the .properties file should get overridden by the command-line arg", settings.outputDir(), "/tmp/warcDownloads");
   }
 
   @Test

--- a/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
@@ -21,14 +21,14 @@ public class TestWasapiDownloaderSettings {
     String[] args = { "-h", "--collectionId", "123", "--jobId=456", "--crawlStartAfter", "2014-03-14", "--crawlStartBefore=2017-03-14" };
     WasapiDownloaderSettings settings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, args);
 
-    assertEquals("baseurl value should come from settings file", settings.baseUrlString(), "http://example.org");
-    assertEquals("username value should come from settings file", settings.username(), "user");
-    assertEquals("password value should come from settings file", settings.password(), "pass");
-    assertEquals("collectionId value should come from args", settings.collectionId(), "123");
-    assertEquals("jobId value should come from args", settings.jobId(), "456");
-    assertEquals("crawlStartAfter value should come from args", settings.crawlStartAfter(), "2014-03-14");
-    assertEquals("crawlStartBefore value should come from args", settings.crawlStartBefore(), "2017-03-14");
-    assertTrue("shouldDisplayHelp value should come from args", settings.shouldDisplayHelp());
+    assertEquals("baseurl value should have come from settings file", settings.baseUrlString(), "http://example.org");
+    assertEquals("username value should have come from settings file", settings.username(), "user");
+    assertEquals("password value should have come from settings file", settings.password(), "pass");
+    assertEquals("collectionId value should have come from args", settings.collectionId(), "123");
+    assertEquals("jobId value should have come from args", settings.jobId(), "456");
+    assertEquals("crawlStartAfter value should have come from args", settings.crawlStartAfter(), "2014-03-14");
+    assertEquals("crawlStartBefore value should have come from args", settings.crawlStartBefore(), "2017-03-14");
+    assertTrue("shouldDisplayHelp value should have come from args", settings.shouldDisplayHelp());
   }
 
   @Test
@@ -38,19 +38,32 @@ public class TestWasapiDownloaderSettings {
     WasapiDownloaderSettings settings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, args);
 
     String helpAndSettingsMsg = settings.getHelpAndSettingsMessage();
+
     assertThat("helpAndSettingsMsg has a usage example", helpAndSettingsMsg, containsString("usage: bin/wasapi-downloader"));
+    assertThat("helpAndSettingsMsg lists baseurl arg", helpAndSettingsMsg, containsString("--baseurl <arg>"));
+    assertThat("helpAndSettingsMsg lists username arg", helpAndSettingsMsg, containsString("--username <arg>"));
+    assertThat("helpAndSettingsMsg lists password arg", helpAndSettingsMsg, containsString("--password <arg>"));
     assertThat("helpAndSettingsMsg lists collectionId arg", helpAndSettingsMsg, containsString("--collectionId <arg>"));
     assertThat("helpAndSettingsMsg lists crawlStartAfter arg", helpAndSettingsMsg, containsString("--crawlStartAfter <arg>"));
     assertThat("helpAndSettingsMsg lists crawlStartBefore arg", helpAndSettingsMsg, containsString("--crawlStartBefore <arg>"));
     assertThat("helpAndSettingsMsg lists help flag", helpAndSettingsMsg, containsString("-h,--help"));
     assertThat("helpAndSettingsMsg lists jobId arg", helpAndSettingsMsg, containsString("--jobId <arg>"));
+
     assertThat("helpAndSettingsMsg hides password value", helpAndSettingsMsg, containsString("password : [password hidden]"));
     assertThat("helpAndSettingsMsg lists crawlStartAfter value", helpAndSettingsMsg, containsString("crawlStartAfter : 2014-03-14"));
     assertThat("helpAndSettingsMsg lists crawlStartBefore value", helpAndSettingsMsg, containsString("crawlStartBefore : 2017-03-14"));
     assertThat("helpAndSettingsMsg lists help flag value", helpAndSettingsMsg, containsString("help : true"));
+    assertThat("helpAndSettingsMsg lists jobId value", helpAndSettingsMsg, containsString("jobId : 456"));
     assertThat("helpAndSettingsMsg lists collectionId value", helpAndSettingsMsg, containsString("collectionId : 123"));
     assertThat("helpAndSettingsMsg lists baseurl value", helpAndSettingsMsg, containsString("baseurl : http://example.org"));
     assertThat("helpAndSettingsMsg lists username value", helpAndSettingsMsg, containsString("username : user"));
+  }
+
+  @Test
+  public void argsOverrideSettings() throws SettingsLoadException {
+    String[] args = { "--username=user2" };
+    WasapiDownloaderSettings settings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, args);
+    assertEquals("the username from the .properties file should get overridden by the command-line arg", settings.username(), "user2");
   }
 
   @Test

--- a/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
@@ -24,7 +24,7 @@ public class TestWasapiDownloaderSettings {
     assertEquals("baseurl value should have come from settings file", settings.baseUrlString(), "http://example.org");
     assertEquals("username value should have come from settings file", settings.username(), "user");
     assertEquals("password value should have come from settings file", settings.password(), "pass");
-    assertEquals("outputDir value should have come from settings file", settings.outputDir(), "/var/downloadedWarcFiles");
+    assertEquals("outputBaseDir value should have come from settings file", settings.outputBaseDir(), "/var/downloadedWarcFiles");
     assertEquals("collectionId value should have come from args", settings.collectionId(), "123");
     assertEquals("jobId value should have come from args", settings.jobId(), "456");
     assertEquals("crawlStartAfter value should have come from args", settings.crawlStartAfter(), "2014-03-14");
@@ -33,7 +33,7 @@ public class TestWasapiDownloaderSettings {
   }
 
   @Test
-  @SuppressWarnings("checkstyle:NoWhitespaceAfter")
+  @SuppressWarnings({"checkstyle:NoWhitespaceAfter", "checkstyle:MethodLength"})
   public void getHelpAndSettingsMessage_containsUsageAndSettingsInfo() throws SettingsLoadException {
     String[] args = { "-h", "--collectionId", "123", "--jobId=456", "--crawlStartAfter", "2014-03-14", "--crawlStartBefore=2017-03-14" };
     WasapiDownloaderSettings settings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, args);
@@ -61,11 +61,12 @@ public class TestWasapiDownloaderSettings {
   }
 
   @Test
+  @SuppressWarnings({"checkstyle:NoWhitespaceAfter", "checkstyle:LineLength"})
   public void argsOverrideSettings() throws SettingsLoadException {
-    String[] args = { "--username=user2", "--outputDir=/tmp/warcDownloads" };
+    String[] args = { "--username=user2", "--outputBaseDir=/tmp/warcDownloads" };
     WasapiDownloaderSettings settings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, args);
     assertEquals("the username from the .properties file should get overridden by the command-line arg", settings.username(), "user2");
-    assertEquals("the outputDir from the .properties file should get overridden by the command-line arg", settings.outputDir(), "/tmp/warcDownloads");
+    assertEquals("the outputBaseDir from the .properties file should get overridden by the command-line arg", settings.outputBaseDir(), "/tmp/warcDownloads");
   }
 
   @Test


### PR DESCRIPTION
* allow any setting to come from either the command-line args or the .properties file.  if a setting is specified in both, the value from the arg should be used.
* add a setting for the output directory (where the downloaded WARC files go).

closes #54
closes #35