### PR TITLE
allow authurl to get picked up from command line args, add tests

### DIFF
--- a/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
@@ -23,6 +23,7 @@ public class WasapiDownloaderSettings {
   // * add an accessor method (preferably with a name corresponding to the setting name)
   // * add to the tests to make sure it shows up in the usage info and settings dump
   public static final String BASE_URL_PARAM_NAME = "baseurl";
+  public static final String AUTH_URL_PARAM_NAME = "authurl";
   public static final String USERNAME_PARAM_NAME = "username";
   public static final String PASSWORD_PARAM_NAME = "password";
   public static final String HELP_PARAM_NAME = "help";
@@ -40,6 +41,7 @@ public class WasapiDownloaderSettings {
   private static Option[] optList = {
     Option.builder("h").longOpt(HELP_PARAM_NAME).desc("print this message (which describes expected arguments and dumps current config)").build(),
     buildArgOption(BASE_URL_PARAM_NAME, "the base URL of the WASAPI server from which to pull WARC files"),
+    buildArgOption(AUTH_URL_PARAM_NAME, "the WASAPI server URL at which login credentials are passed"),
     buildArgOption(USERNAME_PARAM_NAME, "the username for WASAPI server login"),
     buildArgOption(PASSWORD_PARAM_NAME, "the password for WASAPI server login"),
     buildArgOption(COLLECTION_ID_PARAM_NAME, "a collection from which to download crawl files"),
@@ -79,7 +81,7 @@ public class WasapiDownloaderSettings {
   }
 
   public String authUrlString() {
-    return settings.getProperty("authurl");
+    return settings.getProperty(AUTH_URL_PARAM_NAME);
   }
 
   public String username() {

--- a/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
@@ -22,6 +22,7 @@ public class TestWasapiDownloaderSettings {
     WasapiDownloaderSettings settings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, args);
 
     assertEquals("baseurl value should have come from settings file", settings.baseUrlString(), "http://example.org");
+    assertEquals("authurl value should have come from settings file", settings.authUrlString(), "http://example.org/login");
     assertEquals("username value should have come from settings file", settings.username(), "user");
     assertEquals("password value should have come from settings file", settings.password(), "pass");
     assertEquals("outputBaseDir value should have come from settings file", settings.outputBaseDir(), "/var/downloadedWarcFiles");
@@ -42,6 +43,7 @@ public class TestWasapiDownloaderSettings {
 
     assertThat("helpAndSettingsMsg has a usage example", helpAndSettingsMsg, containsString("usage: bin/wasapi-downloader"));
     assertThat("helpAndSettingsMsg lists baseurl arg", helpAndSettingsMsg, containsString("--baseurl <arg>"));
+    assertThat("helpAndSettingsMsg lists authurl arg", helpAndSettingsMsg, containsString("--authurl <arg>"));
     assertThat("helpAndSettingsMsg lists username arg", helpAndSettingsMsg, containsString("--username <arg>"));
     assertThat("helpAndSettingsMsg lists password arg", helpAndSettingsMsg, containsString("--password <arg>"));
     assertThat("helpAndSettingsMsg lists collectionId arg", helpAndSettingsMsg, containsString("--collectionId <arg>"));
@@ -57,6 +59,7 @@ public class TestWasapiDownloaderSettings {
     assertThat("helpAndSettingsMsg lists jobId value", helpAndSettingsMsg, containsString("jobId : 456"));
     assertThat("helpAndSettingsMsg lists collectionId value", helpAndSettingsMsg, containsString("collectionId : 123"));
     assertThat("helpAndSettingsMsg lists baseurl value", helpAndSettingsMsg, containsString("baseurl : http://example.org"));
+    assertThat("helpAndSettingsMsg lists authurl value", helpAndSettingsMsg, containsString("authurl : http://example.org/login"));
     assertThat("helpAndSettingsMsg lists username value", helpAndSettingsMsg, containsString("username : user"));
   }
 


### PR DESCRIPTION
if we do add an `authurl` setting, this would be the way to do it so that it behaves like the other settings (i.e., is available via either `settings.properties` or the cmd line args).

i have no preference as to whether this gets merged to the parent branch, or just ripped off and re-incorporated manually (since that branch is being actively worked on for style stuff at the moment anyway).