### PR TITLE
Improve networking test coverage, minor refactorings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,3 +105,11 @@ jar {
         attributes(jarAttributes)
     }
 }
+
+compileJava {
+    options.compilerArgs += ["-Xlint:unchecked", "-Xlint:deprecation"]
+}
+
+compileTestJava {
+    options.compilerArgs += ["-Xlint:unchecked", "-Xlint:deprecation"]
+}

--- a/src/edu/stanford/dlss/was/WasapiClient.java
+++ b/src/edu/stanford/dlss/was/WasapiClient.java
@@ -44,8 +44,8 @@ public class WasapiClient {
   }
 
 
-  public <T> T execute(HttpGet jsonRequest, ResponseHandler<? extends T> rh) throws IOException {
-    return wasapiClient.execute(jsonRequest, rh, wasapiContext);
+  public <T> T execute(HttpGet request, ResponseHandler<? extends T> rh) throws IOException {
+    return wasapiClient.execute(request, rh, wasapiContext);
   }
 
 

--- a/src/edu/stanford/dlss/was/WasapiConnection.java
+++ b/src/edu/stanford/dlss/was/WasapiConnection.java
@@ -7,31 +7,23 @@ import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.methods.HttpGet;
 
 public class WasapiConnection {
-
   private WasapiClient wasapiClient;
-  private JsonResponseHandler jsonResponseHandler;
-  private DownloadResponseHandler downloadResponseHandler;
 
-
-  public WasapiConnection(WasapiClient wasapiClient,
-                          JsonResponseHandler jsonHandler,
-                          DownloadResponseHandler downloadHandler) throws IOException {
+  public WasapiConnection(WasapiClient wasapiClient) throws IOException {
     this.wasapiClient = wasapiClient;
-    this.jsonResponseHandler = jsonHandler;
-    this.downloadResponseHandler = downloadHandler;
     this.wasapiClient.login();
   }
 
 
   public WasapiResponse jsonQuery(String requestURL) throws IOException {
     HttpGet jsonRequest = new HttpGet(requestURL);
-    return wasapiClient.execute(jsonRequest, jsonResponseHandler);
+    return wasapiClient.execute(jsonRequest, new JsonResponseHandler());
   }
 
 
   public Boolean downloadQuery(String downloadURL, final String outputPath) throws ClientProtocolException, HttpResponseException, IOException {
     HttpGet fileRequest = new HttpGet(downloadURL);
-    return wasapiClient.execute(fileRequest, downloadResponseHandler);
+    return wasapiClient.execute(fileRequest, new DownloadResponseHandler(outputPath));
   }
 
 
@@ -39,3 +31,4 @@ public class WasapiConnection {
     wasapiClient.close();
   }
 }
+

--- a/test/edu/stanford/dlss/was/TestDownloadResponseHandler.java
+++ b/test/edu/stanford/dlss/was/TestDownloadResponseHandler.java
@@ -16,7 +16,6 @@ import org.junit.*;
 import static org.junit.Assert.*;
 import org.mockito.*;
 import org.mockito.Mockito.*;
-import org.mockito.Matchers.*;
 import org.mockito.invocation.*;
 import org.mockito.stubbing.*;
 
@@ -71,7 +70,7 @@ public class TestDownloadResponseHandler {
         new File(OUTPUT_FILE_PATH).createNewFile();
         return null;
       }
-    }).when(mockEntity).writeTo(Matchers.<FileOutputStream>any());
+    }).when(mockEntity).writeTo(ArgumentMatchers.<FileOutputStream>any(FileOutputStream.class));
 
     boolean returnValue = handler.handleResponse(mockResponse);
     assertEquals(returnValue, true);

--- a/test/edu/stanford/dlss/was/TestJsonResponseHandler.java
+++ b/test/edu/stanford/dlss/was/TestJsonResponseHandler.java
@@ -16,7 +16,6 @@ import org.junit.*;
 import static org.junit.Assert.*;
 import org.mockito.*;
 import org.mockito.Mockito.*;
-import org.mockito.Matchers.*;
 
 public class TestJsonResponseHandler {
 

--- a/test/edu/stanford/dlss/was/TestWasapiClient.java
+++ b/test/edu/stanford/dlss/was/TestWasapiClient.java
@@ -1,0 +1,49 @@
+package edu.stanford.dlss.was;
+
+import java.io.IOException;
+
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import org.junit.*;
+import static org.mockito.Mockito.*;
+
+public class TestWasapiClient {
+  @Test
+  public void constructorInitializesCorrectly() throws IOException, SettingsLoadException {
+    WasapiDownloaderSettings settings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, null);
+    WasapiClient testClient = new WasapiClient(settings);
+
+    assertNotNull(testClient.wasapiClient);
+    assertNotNull(testClient.wasapiContext);
+    assertNotNull(testClient.cookieStore);
+    assertEquals(testClient.settings, settings);
+  }
+
+  @Test
+  public void closeCloses() throws IOException, SettingsLoadException {
+    WasapiClient testClient = new WasapiClient(new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    CloseableHttpClient mockHttpClient = mock(CloseableHttpClient.class);
+    testClient.wasapiClient = mockHttpClient;
+
+    testClient.close();
+
+    verify(mockHttpClient, times(1)).close();
+  }
+
+  @Test
+  public void executeUsesContext() throws IOException, SettingsLoadException {
+    WasapiClient testClient = new WasapiClient(new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    CloseableHttpClient mockHttpClient = mock(CloseableHttpClient.class);
+    testClient.wasapiClient = mockHttpClient;
+
+    JsonResponseHandler mockHandler = mock(JsonResponseHandler.class);
+    HttpGet mockRequest = mock(HttpGet.class);
+
+    testClient.execute(mockRequest, mockHandler);
+
+    verify(mockHttpClient, times(1)).execute(mockRequest, mockHandler, testClient.wasapiContext);
+  }
+}

--- a/test/edu/stanford/dlss/was/TestWasapiConnection.java
+++ b/test/edu/stanford/dlss/was/TestWasapiConnection.java
@@ -1,0 +1,46 @@
+package edu.stanford.dlss.was;
+
+import java.io.IOException;
+
+import org.apache.http.client.methods.HttpGet;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import org.junit.*;
+import static org.mockito.Mockito.*;
+import org.mockito.ArgumentMatchers;
+
+public class TestWasapiConnection {
+
+  private static final String JSON_QUERY = "http://example.com/example.json";
+  private static final String DOWNLOAD_QUERY = "http://example.com/download?file=example.warc";
+  private static final String OUTPUT_PATH = "/dev/null";
+
+  @Test
+  public void constructorCallsLogin() throws IOException {
+    WasapiClient mockClient = mock(WasapiClient.class);
+    WasapiConnection testConnection = new WasapiConnection(mockClient);
+
+    verify(mockClient, times(1)).login();
+  }
+
+  @Test
+  public void jsonQueryCallsExecute() throws IOException {
+    WasapiClient mockClient = mock(WasapiClient.class);
+    WasapiConnection testConnection = new WasapiConnection(mockClient);
+    testConnection.jsonQuery(JSON_QUERY);
+
+    verify(mockClient, times(1)).execute(ArgumentMatchers.<HttpGet>any(HttpGet.class),
+                                         ArgumentMatchers.<JsonResponseHandler>any(JsonResponseHandler.class));
+  }
+
+  @Test
+  public void downloadQueryCallsExecute() throws IOException {
+    WasapiClient mockClient = mock(WasapiClient.class);
+    WasapiConnection testConnection = new WasapiConnection(mockClient);
+    testConnection.downloadQuery(JSON_QUERY, OUTPUT_PATH);
+
+    verify(mockClient, times(1)).execute(ArgumentMatchers.<HttpGet>any(HttpGet.class),
+                                         ArgumentMatchers.<DownloadResponseHandler>any(DownloadResponseHandler.class));
+  }
+}


### PR DESCRIPTION
This PR does some fairly minor refactoring of the networking methods that I hope will make them easier to use. It also adds warnings for unchecked type conversions and deprecated methods to the compiler options.

Fixes #59 
Fixes #60 
