### PR TITLE
Move validate checksum

### DIFF
--- a/src/edu/stanford/dlss/was/DownloadResponseHandler.java
+++ b/src/edu/stanford/dlss/was/DownloadResponseHandler.java
@@ -21,7 +21,7 @@ public class DownloadResponseHandler implements ResponseHandler<Boolean> {
     HttpEntity entity = response.getEntity();
 
 
-    if (WasapiResponseValidator.validateResponse(response.getStatusLine(), entity == null)) {
+    if (WasapiValidator.validateResponse(response.getStatusLine(), entity == null)) {
       FileOutputStream fouts = new FileOutputStream(outputPath);
       entity.writeTo(fouts);
       fouts.close();

--- a/src/edu/stanford/dlss/was/JsonResponseHandler.java
+++ b/src/edu/stanford/dlss/was/JsonResponseHandler.java
@@ -13,7 +13,7 @@ public class JsonResponseHandler implements ResponseHandler<WasapiResponse> {
   @Override
   public WasapiResponse handleResponse(final HttpResponse response) throws ClientProtocolException, HttpResponseException, IOException {
     HttpEntity entity = response.getEntity();
-    if (WasapiResponseValidator.validateResponse(response.getStatusLine(), entity == null))
+    if (WasapiValidator.validateResponse(response.getStatusLine(), entity == null))
       return new WasapiResponseParser().parse(entity.getContent());
     else return null;
   }

--- a/src/edu/stanford/dlss/was/WasapiDownloader.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloader.java
@@ -1,14 +1,5 @@
 package edu.stanford.dlss.was;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-
-import javax.xml.bind.DatatypeConverter;
-
 public class WasapiDownloader {
   public static final String SETTINGS_FILE_LOCATION = "config/settings.properties";
 
@@ -17,16 +8,6 @@ public class WasapiDownloader {
 
   public WasapiDownloader(String settingsFileLocation, String[] args) throws SettingsLoadException {
     settings = new WasapiDownloaderSettings(settingsFileLocation, args);
-  }
-
-  public static boolean validateMd5(String expectedChecksum, String filePath)
-      throws NoSuchAlgorithmException, IOException {
-    return validateChecksum("MD5", expectedChecksum, filePath);
-  }
-
-  public static boolean validateSha1(String expectedChecksum, String filePath)
-      throws NoSuchAlgorithmException, IOException {
-    return validateChecksum("SHA-1", expectedChecksum, filePath);
   }
 
   public void executeFromCmdLine() {
@@ -44,25 +25,5 @@ public class WasapiDownloader {
     downloader.executeFromCmdLine();
   }
 
-
-  /**
-   * convert byte array to a hexadecimal string. Note that this generates hexadecimal in lower case.
-   */
-  private static String bytesToHex(byte[] byteArray) {
-    return DatatypeConverter.printHexBinary(byteArray).toLowerCase();
-  }
-
-  /**
-   * @param algorithm - checksum algorithm to use, per
-        https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#MessageDigest
-   */
-  public static boolean validateChecksum(String algorithm, String expectedChecksum, String filePath)
-      throws NoSuchAlgorithmException, IOException {
-    Path path = Paths.get(filePath);
-    MessageDigest digest = MessageDigest.getInstance(algorithm);
-    byte[] computedChecksumBytes = digest.digest(Files.readAllBytes(path));
-    String computedChecksumString = bytesToHex(computedChecksumBytes);
-    return expectedChecksum.toLowerCase().compareTo(computedChecksumString) == 0;
-  }
 
 }

--- a/src/edu/stanford/dlss/was/WasapiResponseValidator.java
+++ b/src/edu/stanford/dlss/was/WasapiResponseValidator.java
@@ -1,5 +1,14 @@
 package edu.stanford.dlss.was;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import javax.xml.bind.DatatypeConverter;
+
 import org.apache.http.StatusLine;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpResponseException;
@@ -18,4 +27,35 @@ public class WasapiResponseValidator {
     }
     return true;
   }
+
+  public static boolean validateMd5(String expectedChecksum, String filePath)
+      throws NoSuchAlgorithmException, IOException {
+    return validateChecksum("MD5", expectedChecksum, filePath);
+  }
+
+  public static boolean validateSha1(String expectedChecksum, String filePath)
+      throws NoSuchAlgorithmException, IOException {
+    return validateChecksum("SHA-1", expectedChecksum, filePath);
+  }
+
+  /**
+   * convert byte array to a hexadecimal string. Note that this generates hexadecimal in lower case.
+   */
+  private static String bytesToHex(byte[] byteArray) {
+    return DatatypeConverter.printHexBinary(byteArray).toLowerCase();
+  }
+
+  /**
+   * @param algorithm - checksum algorithm to use, per
+        https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#MessageDigest
+   */
+  private static boolean validateChecksum(String algorithm, String expectedChecksum, String filePath)
+      throws NoSuchAlgorithmException, IOException {
+    Path path = Paths.get(filePath);
+    MessageDigest digest = MessageDigest.getInstance(algorithm);
+    byte[] computedChecksumBytes = digest.digest(Files.readAllBytes(path));
+    String computedChecksumString = bytesToHex(computedChecksumBytes);
+    return expectedChecksum.toLowerCase().compareTo(computedChecksumString) == 0;
+  }
+
 }

--- a/src/edu/stanford/dlss/was/WasapiValidator.java
+++ b/src/edu/stanford/dlss/was/WasapiValidator.java
@@ -14,7 +14,7 @@ import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpResponseException;
 
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
-public class WasapiResponseValidator {
+public class WasapiValidator {
 
   private static final int STATUS_CODE_THRESHOLD = 300;
 

--- a/test/edu/stanford/dlss/was/TestWasapiDownloader.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloader.java
@@ -1,9 +1,5 @@
 package edu.stanford.dlss.was;
 
-import java.io.File;
-import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
-
 import static org.junit.Assert.*;
 import org.junit.*;
 
@@ -25,33 +21,5 @@ public class TestWasapiDownloader {
   public void main_withHelp_canExecuteWithoutCrashing() throws SettingsLoadException {
     String[] args = { "-h" };
     WasapiDownloader.main(args);
-  }
-
-  private static final char SEP = File.separatorChar;
-  private static final String FIXTURE_WARC_PATH = "test" + SEP + "fixtures" + SEP + "small-file.warc.gz";
-  private static final String FIXTURE_MD5 = "f08b0bf60733b61216e288cb7620bd4a";
-  private static final String FIXTURE_SHA1 = "c7dff430d5d725c3d2b786d5b247eb5a8d53b228";
-
-  @Test
-  public void validateMd5Checksum_withValidChecksum() throws NoSuchAlgorithmException, IOException {
-    assertTrue("md5 checksum expected to validate for small-file.warc.gz", WasapiDownloader.validateMd5(FIXTURE_MD5, FIXTURE_WARC_PATH));
-  }
-
-  @Test
-  public void validateMd5Checksum_withInvalidChecksum() throws NoSuchAlgorithmException, IOException {
-    assertFalse("md5 checksum NOT expected to validate for small-file.warc.gz", WasapiDownloader.validateMd5(FIXTURE_MD5 + "9", FIXTURE_WARC_PATH));
-    assertFalse("md5 checksum NOT expected to validate for small-file.warc.gz", WasapiDownloader.validateMd5(FIXTURE_SHA1, FIXTURE_WARC_PATH));
-  }
-
-  @Test
-  public void validateSha1Checksum_withValidChecksum() throws NoSuchAlgorithmException, IOException {
-    assertTrue("sha1 checksum expected to validate for small-file.warc.gz", WasapiDownloader.validateSha1(FIXTURE_SHA1, FIXTURE_WARC_PATH));
-  }
-
-  @Test
-  public void validateSha1Checksum_withInvalidChecksum() throws NoSuchAlgorithmException, IOException {
-    String expectationErrorMsg = "sha1 checksum NOT expected to validate for small-file.warc.gz";
-    assertFalse(expectationErrorMsg, WasapiDownloader.validateSha1(FIXTURE_SHA1 + "9", FIXTURE_WARC_PATH));
-    assertFalse(expectationErrorMsg, WasapiDownloader.validateSha1(FIXTURE_MD5, FIXTURE_WARC_PATH));
   }
 }

--- a/test/edu/stanford/dlss/was/TestWasapiResponseValidator.java
+++ b/test/edu/stanford/dlss/was/TestWasapiResponseValidator.java
@@ -9,6 +9,10 @@ import org.apache.http.message.BasicStatusLine;
 import org.junit.*;
 import static org.junit.Assert.*;
 
+import java.io.File;
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+
 public class TestWasapiResponseValidator {
 
   private StatusLine validStatusLine = new BasicStatusLine(new ProtocolVersion("HTTP 1/1", 1, 1), 200, "OK");
@@ -27,5 +31,34 @@ public class TestWasapiResponseValidator {
   @Test
   public void testValidResponse() throws ClientProtocolException, HttpResponseException {
     assertTrue(WasapiResponseValidator.validateResponse(validStatusLine, false));
+  }
+
+  private static final char SEP = File.separatorChar;
+  private static final String FIXTURE_WARC_PATH = "test" + SEP + "fixtures" + SEP + "small-file.warc.gz";
+  private static final String FIXTURE_MD5 = "f08b0bf60733b61216e288cb7620bd4a";
+  private static final String FIXTURE_SHA1 = "c7dff430d5d725c3d2b786d5b247eb5a8d53b228";
+
+  @Test
+  public void validateMd5Checksum_withValidChecksum() throws NoSuchAlgorithmException, IOException {
+    assertTrue("md5 checksum expected to validate for small-file.warc.gz", WasapiResponseValidator.validateMd5(FIXTURE_MD5, FIXTURE_WARC_PATH));
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:LineLength")
+  public void validateMd5Checksum_withInvalidChecksum() throws NoSuchAlgorithmException, IOException {
+    assertFalse("md5 checksum NOT expected to validate for small-file.warc.gz", WasapiResponseValidator.validateMd5(FIXTURE_MD5 + "9", FIXTURE_WARC_PATH));
+    assertFalse("md5 checksum NOT expected to validate for small-file.warc.gz", WasapiResponseValidator.validateMd5(FIXTURE_SHA1, FIXTURE_WARC_PATH));
+  }
+
+  @Test
+  public void validateSha1Checksum_withValidChecksum() throws NoSuchAlgorithmException, IOException {
+    assertTrue("sha1 checksum expected to validate for small-file.warc.gz", WasapiResponseValidator.validateSha1(FIXTURE_SHA1, FIXTURE_WARC_PATH));
+  }
+
+  @Test
+  public void validateSha1Checksum_withInvalidChecksum() throws NoSuchAlgorithmException, IOException {
+    String expectationErrorMsg = "sha1 checksum NOT expected to validate for small-file.warc.gz";
+    assertFalse(expectationErrorMsg, WasapiResponseValidator.validateSha1(FIXTURE_SHA1 + "9", FIXTURE_WARC_PATH));
+    assertFalse(expectationErrorMsg, WasapiResponseValidator.validateSha1(FIXTURE_MD5, FIXTURE_WARC_PATH));
   }
 }

--- a/test/edu/stanford/dlss/was/TestWasapiValidator.java
+++ b/test/edu/stanford/dlss/was/TestWasapiValidator.java
@@ -13,24 +13,24 @@ import java.io.File;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 
-public class TestWasapiResponseValidator {
+public class TestWasapiValidator {
 
   private StatusLine validStatusLine = new BasicStatusLine(new ProtocolVersion("HTTP 1/1", 1, 1), 200, "OK");
   private StatusLine invalidStatusLine = new BasicStatusLine(new ProtocolVersion("HTTP 1/1", 1, 1), 300, "Not Defined");
 
   @Test(expected = ClientProtocolException.class)
   public void testNullEntity() throws ClientProtocolException, HttpResponseException {
-    WasapiResponseValidator.validateResponse(validStatusLine, true);
+    WasapiValidator.validateResponse(validStatusLine, true);
   }
 
   @Test(expected = HttpResponseException.class)
   public void testWrongResponseCode() throws ClientProtocolException, HttpResponseException {
-    WasapiResponseValidator.validateResponse(invalidStatusLine, false);
+    WasapiValidator.validateResponse(invalidStatusLine, false);
   }
 
   @Test
   public void testValidResponse() throws ClientProtocolException, HttpResponseException {
-    assertTrue(WasapiResponseValidator.validateResponse(validStatusLine, false));
+    assertTrue(WasapiValidator.validateResponse(validStatusLine, false));
   }
 
   private static final char SEP = File.separatorChar;
@@ -40,25 +40,25 @@ public class TestWasapiResponseValidator {
 
   @Test
   public void validateMd5Checksum_withValidChecksum() throws NoSuchAlgorithmException, IOException {
-    assertTrue("md5 checksum expected to validate for small-file.warc.gz", WasapiResponseValidator.validateMd5(FIXTURE_MD5, FIXTURE_WARC_PATH));
+    assertTrue("md5 checksum expected to validate for small-file.warc.gz", WasapiValidator.validateMd5(FIXTURE_MD5, FIXTURE_WARC_PATH));
   }
 
   @Test
   @SuppressWarnings("checkstyle:LineLength")
   public void validateMd5Checksum_withInvalidChecksum() throws NoSuchAlgorithmException, IOException {
-    assertFalse("md5 checksum NOT expected to validate for small-file.warc.gz", WasapiResponseValidator.validateMd5(FIXTURE_MD5 + "9", FIXTURE_WARC_PATH));
-    assertFalse("md5 checksum NOT expected to validate for small-file.warc.gz", WasapiResponseValidator.validateMd5(FIXTURE_SHA1, FIXTURE_WARC_PATH));
+    assertFalse("md5 checksum NOT expected to validate for small-file.warc.gz", WasapiValidator.validateMd5(FIXTURE_MD5 + "9", FIXTURE_WARC_PATH));
+    assertFalse("md5 checksum NOT expected to validate for small-file.warc.gz", WasapiValidator.validateMd5(FIXTURE_SHA1, FIXTURE_WARC_PATH));
   }
 
   @Test
   public void validateSha1Checksum_withValidChecksum() throws NoSuchAlgorithmException, IOException {
-    assertTrue("sha1 checksum expected to validate for small-file.warc.gz", WasapiResponseValidator.validateSha1(FIXTURE_SHA1, FIXTURE_WARC_PATH));
+    assertTrue("sha1 checksum expected to validate for small-file.warc.gz", WasapiValidator.validateSha1(FIXTURE_SHA1, FIXTURE_WARC_PATH));
   }
 
   @Test
   public void validateSha1Checksum_withInvalidChecksum() throws NoSuchAlgorithmException, IOException {
     String expectationErrorMsg = "sha1 checksum NOT expected to validate for small-file.warc.gz";
-    assertFalse(expectationErrorMsg, WasapiResponseValidator.validateSha1(FIXTURE_SHA1 + "9", FIXTURE_WARC_PATH));
-    assertFalse(expectationErrorMsg, WasapiResponseValidator.validateSha1(FIXTURE_MD5, FIXTURE_WARC_PATH));
+    assertFalse(expectationErrorMsg, WasapiValidator.validateSha1(FIXTURE_SHA1 + "9", FIXTURE_WARC_PATH));
+    assertFalse(expectationErrorMsg, WasapiValidator.validateSha1(FIXTURE_MD5, FIXTURE_WARC_PATH));
   }
 }


### PR DESCRIPTION
Fixes #63

- move existing checksum validation methods to WasapiResponseValidator
- WasapiResponseValidator renamed to WasapiValidator
