### PR TITLE
Update build and deployment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 
     //For creating mock objects in unit tests
     testCompile "org.mockito:mockito-core:2.+"
+
     // need PowerMock for mocking constructors (local objects within methods)
     testCompile "org.powermock:powermock-module-junit4:1.7+"
     testCompile "org.powermock:powermock-api-mockito2:1.7+"
@@ -118,4 +119,11 @@ compileJava {
 
 compileTestJava {
     options.compilerArgs += ["-Xlint:unchecked", "-Xlint:deprecation"]
+}
+
+startScripts {
+    doLast {
+        unixScript.text = unixScript.text
+            .replace('DEFAULT_JVM_OPTS=\"\"', 'DEFAULT_JVM_OPTS=\"-Xmx10g\"')
+    }
 }

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -37,11 +37,10 @@ set :linked_dirs, %w{build config .gradle}
 before 'deploy:finished', 'shared_configs:update'
 
 namespace :gradle do
-  desc 'Assemble a jar archive containing the main classes.'
-  task :jar do
+  task :install_dist do
     on roles(:app) do
-      execute "cd #{current_path} && ./gradlew jar"
+      execute "cd #{current_path} && ./gradlew installDist"
     end
   end
 end
-after 'deploy:finished', 'gradle:jar'
+after 'deploy:finished', 'gradle:install_dist'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "wasapi-downloader"


### PR DESCRIPTION
Closes #79 

(partially, at least)

This PR updates the build scripts in order to:

- Generate a `build/install/wasapi-downloader/...` directory upon deployment instead of e.g. `build/install/20170523201737`.
- Run Gradle's installDist task when deploying (no longer build jar file since we don't expect to need it).
- Set the heap space to a hopefully big enough value.