### PR TITLE
get all the result pages

### DIFF
--- a/src/edu/stanford/dlss/was/WasapiConnection.java
+++ b/src/edu/stanford/dlss/was/WasapiConnection.java
@@ -15,7 +15,13 @@ public class WasapiConnection {
   }
 
 
+  /**
+   * @return null when requestURL is null (for callers that just page through responses' "next" links)
+   */
   public WasapiResponse jsonQuery(String requestURL) throws IOException {
+    if (requestURL == null)
+      return null;
+
     HttpGet jsonRequest = new HttpGet(requestURL);
     return wasapiClient.execute(jsonRequest, new JsonResponseHandler());
   }
@@ -31,4 +37,3 @@ public class WasapiConnection {
     wasapiClient.close();
   }
 }
-

--- a/src/edu/stanford/dlss/was/WasapiConnection.java
+++ b/src/edu/stanford/dlss/was/WasapiConnection.java
@@ -1,6 +1,8 @@
 package edu.stanford.dlss.was;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.LinkedList;
 
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpResponseException;
@@ -26,6 +28,17 @@ public class WasapiConnection {
     return wasapiClient.execute(jsonRequest, new JsonResponseHandler());
   }
 
+  public List<WasapiResponse> pagedJsonQuery(String requestURL) throws IOException {
+    List<WasapiResponse> wasapiRespList = new LinkedList<WasapiResponse>();
+
+    WasapiResponse wasapiResp = jsonQuery(requestURL);
+    while(wasapiResp != null) {
+      wasapiRespList.add(wasapiResp);
+      wasapiResp = jsonQuery(wasapiResp.getNext());
+    }
+
+    return wasapiRespList;
+  }
 
   public Boolean downloadQuery(String downloadURL, final String outputPath) throws ClientProtocolException, HttpResponseException, IOException {
     HttpGet fileRequest = new HttpGet(downloadURL);

--- a/src/edu/stanford/dlss/was/WasapiCrawlSelector.java
+++ b/src/edu/stanford/dlss/was/WasapiCrawlSelector.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public class WasapiCrawlSelector {
 
-  public Map<Integer, List<WasapiFile>> crawlIdToFiles = new HashMap<Integer, List<WasapiFile>>();
+  protected Map<Integer, List<WasapiFile>> crawlIdToFiles = new HashMap<Integer, List<WasapiFile>>();
 
   public WasapiCrawlSelector(WasapiFile[] candidateFiles) {
     addCandidateFiles(candidateFiles);

--- a/src/edu/stanford/dlss/was/WasapiCrawlSelector.java
+++ b/src/edu/stanford/dlss/was/WasapiCrawlSelector.java
@@ -13,6 +13,11 @@ public class WasapiCrawlSelector {
     addCandidateFiles(candidateFiles);
   }
 
+  public WasapiCrawlSelector(List<WasapiResponse> respList) {
+    for (WasapiResponse resp : respList)
+      addCandidateFiles(resp.getFiles());
+  }
+
   /**
    * expects lastKnownCrawlId to be validated before it gets here: expects positive int
    * if arg is 0, it will return all WARCs in the candidate files

--- a/src/edu/stanford/dlss/was/WasapiCrawlSelector.java
+++ b/src/edu/stanford/dlss/was/WasapiCrawlSelector.java
@@ -7,10 +7,10 @@ import java.util.Map;
 
 public class WasapiCrawlSelector {
 
-  public Map<Integer, List<WasapiFile>> crawlIdToFiles;
+  public Map<Integer, List<WasapiFile>> crawlIdToFiles = new HashMap<Integer, List<WasapiFile>>();
 
   public WasapiCrawlSelector(WasapiFile[] candidateFiles) {
-    setCrawlIdToFiles(candidateFiles);
+    addCandidateFiles(candidateFiles);
   }
 
   /**
@@ -31,19 +31,16 @@ public class WasapiCrawlSelector {
     return crawlIdToFiles.get(crawlId);
   }
 
-  private void setCrawlIdToFiles(WasapiFile[] candidateFiles) {
-    if (crawlIdToFiles == null) {
-      crawlIdToFiles = new HashMap<Integer, List<WasapiFile>>();
-      for (WasapiFile file : candidateFiles) {
-        Integer crawlIdInteger = Integer.valueOf(file.getCrawlId());
-        List<WasapiFile> files;
-        if (crawlIdToFiles.isEmpty() || crawlIdToFiles.get(crawlIdInteger) == null)
-          files = new ArrayList<WasapiFile>();
-        else
-          files = crawlIdToFiles.get(crawlIdInteger);
-        files.add(file);
-        crawlIdToFiles.put(crawlIdInteger, files);
-      }
+  private void addCandidateFiles(WasapiFile[] candidateFiles) {
+    for (WasapiFile file : candidateFiles) {
+      Integer crawlIdInteger = Integer.valueOf(file.getCrawlId());
+      List<WasapiFile> files;
+      if (crawlIdToFiles.isEmpty() || crawlIdToFiles.get(crawlIdInteger) == null)
+        files = new ArrayList<WasapiFile>();
+      else
+        files = crawlIdToFiles.get(crawlIdInteger);
+      files.add(file);
+      crawlIdToFiles.put(crawlIdInteger, files);
     }
   }
 }

--- a/src/edu/stanford/dlss/was/WasapiDownloader.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloader.java
@@ -37,11 +37,11 @@ public class WasapiDownloader {
   // package level method for testing
   void downloadSelectedWarcs() throws IOException {
     // System.out.println("DEBUG: about to request " + getFileSetRequestUrl());
-    WasapiResponse wasapiResp = getWasapiConn().jsonQuery(getFileSetRequestUrl());
+    List<WasapiResponse> wasapiRespList = getWasapiConn().pagedJsonQuery(getFileSetRequestUrl());
     // System.out.println(wasapiResp.toString());
 
-    if (wasapiResp != null) {
-      WasapiCrawlSelector crawlSelector = new WasapiCrawlSelector(wasapiResp.getFiles());
+    if (wasapiRespList != null && wasapiRespList.get(0) != null) {
+      WasapiCrawlSelector crawlSelector = new WasapiCrawlSelector(wasapiRespList);
       for (Integer crawlId : desiredCrawlIds(crawlSelector)) {
         for (WasapiFile file : crawlSelector.getFilesForCrawl(crawlId)) {
           // TODO:  make a separate method for downloading individual file?

--- a/test/edu/stanford/dlss/was/TestWasapiConnection.java
+++ b/test/edu/stanford/dlss/was/TestWasapiConnection.java
@@ -1,6 +1,7 @@
 package edu.stanford.dlss.was;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.apache.http.client.methods.HttpGet;
 
@@ -10,6 +11,8 @@ import static org.mockito.Mockito.*;
 import org.mockito.ArgumentMatchers;
 
 public class TestWasapiConnection {
+  private static final String ORIG_QUERY_URL = "https://example.org/query";
+  private static final String NEXT_URL = "https://example.org/query?page=2";
 
   private static final String JSON_QUERY = "http://example.com/example.json";
   // private static final String DOWNLOAD_QUERY = "http://example.com/download?file=example.warc";
@@ -41,6 +44,47 @@ public class TestWasapiConnection {
   }
 
   @Test
+  public void pagedJsonQuery_loopsThroughAndReturnsResponseList() throws IOException {
+    WasapiClient mockClient = mock(WasapiClient.class);
+    WasapiConnection spyConnection = spy(new WasapiConnection(mockClient));
+
+    WasapiResponse[] responses = {
+      mockResponseNotLast(),
+      mockResponseLast()
+    };
+    doReturn(responses[0]).when(spyConnection).jsonQuery(ORIG_QUERY_URL);
+    doReturn(responses[1]).when(spyConnection).jsonQuery(NEXT_URL);
+
+    List<WasapiResponse> respList = spyConnection.pagedJsonQuery(ORIG_QUERY_URL);
+    assertEquals("response list should have 2 entries", 2, respList.size());
+    assertEquals("response list's first entry should be first response", responses[0], respList.get(0));
+    assertEquals("response list's second entry should be second response", responses[1], respList.get(1));
+  }
+
+  @Test
+  public void pagedJsonQuery_handlesSinglePageResponse() throws IOException {
+    WasapiClient mockClient = mock(WasapiClient.class);
+    WasapiConnection spyConnection = spy(new WasapiConnection(mockClient));
+    WasapiResponse mockResponse = mockResponseLast();
+
+    doReturn(mockResponse).when(spyConnection).jsonQuery(ORIG_QUERY_URL);
+
+    List<WasapiResponse> respList = spyConnection.pagedJsonQuery(ORIG_QUERY_URL);
+    assertEquals("response list should have 1 entry", 1, respList.size());
+    assertEquals("response list's only entry should be mockResponse", mockResponse, respList.get(0));
+  }
+
+  @Test
+  public void pagedJsonQuery_handlesNullResponse() throws IOException {
+    WasapiClient mockClient = mock(WasapiClient.class);
+    WasapiConnection spyConnection = spy(new WasapiConnection(mockClient));
+
+    doReturn(null).when(spyConnection).jsonQuery(ORIG_QUERY_URL);
+    List<WasapiResponse> respList = spyConnection.pagedJsonQuery(ORIG_QUERY_URL);
+    assertEquals("response list should be empty", 0, respList.size());
+  }
+
+  @Test
   public void downloadQueryCallsExecute() throws IOException {
     WasapiClient mockClient = mock(WasapiClient.class);
     WasapiConnection testConnection = new WasapiConnection(mockClient);
@@ -48,5 +92,18 @@ public class TestWasapiConnection {
 
     verify(mockClient, times(1)).execute(ArgumentMatchers.<HttpGet>any(HttpGet.class),
                                          ArgumentMatchers.<DownloadResponseHandler>any(DownloadResponseHandler.class));
+  }
+
+
+  private WasapiResponse mockResponseNotLast() {
+    WasapiResponse mockResp = mock(WasapiResponse.class);
+    doReturn(NEXT_URL).when(mockResp).getNext();
+    return mockResp;
+  }
+
+  private WasapiResponse mockResponseLast() {
+    WasapiResponse mockResp = mock(WasapiResponse.class);
+    doReturn(null).when(mockResp).getNext();
+    return mockResp;
   }
 }

--- a/test/edu/stanford/dlss/was/TestWasapiConnection.java
+++ b/test/edu/stanford/dlss/was/TestWasapiConnection.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import org.apache.http.client.methods.HttpGet;
 
 import org.junit.*;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import org.mockito.ArgumentMatchers;
 
@@ -30,6 +31,13 @@ public class TestWasapiConnection {
 
     verify(mockClient, times(1)).execute(ArgumentMatchers.<HttpGet>any(HttpGet.class),
                                          ArgumentMatchers.<JsonResponseHandler>any(JsonResponseHandler.class));
+  }
+
+  @Test
+  public void jsonQuery_handlesNullRequestUrl() throws IOException {
+    WasapiClient mockClient = mock(WasapiClient.class);
+    WasapiConnection testConnection = new WasapiConnection(mockClient);
+    assertNull("jsonQuery should just return a null response if requestURL is null", testConnection.jsonQuery(null));
   }
 
   @Test

--- a/test/edu/stanford/dlss/was/TestWasapiCrawlSelector.java
+++ b/test/edu/stanford/dlss/was/TestWasapiCrawlSelector.java
@@ -31,7 +31,7 @@ public class TestWasapiCrawlSelector {
   }
 
   @Test
-  public void setCrawlIdToFiles_worksWithMultipleFilesPerCrawl() {
+  public void addCandidateFiles_worksWithMultipleFilesPerCrawl() {
     file2.setCrawlId(file1.getCrawlId());
     file2.setCrawlStartDateStr(file1.getCrawlStartDateStr());
     WasapiCrawlSelector selector = new WasapiCrawlSelector(candidateFiles);

--- a/test/edu/stanford/dlss/was/TestWasapiCrawlSelector.java
+++ b/test/edu/stanford/dlss/was/TestWasapiCrawlSelector.java
@@ -1,6 +1,7 @@
 package edu.stanford.dlss.was;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import static org.junit.Assert.*;
 import org.junit.*;
@@ -25,9 +26,41 @@ public class TestWasapiCrawlSelector {
   }
 
   @Test
-  public void constructor_loadsCrawlIdToFiles() {
+  public void constructor_loadsCrawlIdToFiles_fromFileArray() {
     WasapiCrawlSelector selector = new WasapiCrawlSelector(candidateFiles);
     assertTrue("crawlIdsToFiles should be populated", selector.crawlIdToFiles.size() == 3);
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:MethodLength")
+  public void constructor_loadsCrawlIdToFiles_fromRespList() {
+    WasapiFile file4 = new WasapiFile();
+    WasapiFile file5 = new WasapiFile();
+    file4.setCrawlId(333);
+    file4.setCrawlStartDateStr("2012-01-01T00:00:00Z");
+    file5.setCrawlId(555);
+    file5.setCrawlStartDateStr("2013-01-01T00:00:00Z");
+    WasapiFile[] candidateFiles2 = {file4, file5};
+
+    WasapiResponse resp1 = new WasapiResponse();
+    WasapiResponse resp2 = new WasapiResponse();
+    resp1.setFiles(candidateFiles);
+    resp2.setFiles(candidateFiles2);
+
+    List<WasapiResponse> respList = new ArrayList<WasapiResponse>();
+    respList.add(resp1);
+    respList.add(resp2);
+
+    WasapiCrawlSelector selector = new WasapiCrawlSelector(respList);
+    assertEquals("crawlIdsToFiles should have four crawls", 4, selector.crawlIdToFiles.size());
+    assertEquals("crawl 111 should have one file", 1, selector.getFilesForCrawl(111).size());
+    assertEquals("crawl 222 should have one file", 1, selector.getFilesForCrawl(222).size());
+    assertEquals("crawl 333 should have two files", 2, selector.getFilesForCrawl(333).size());
+    assertEquals("crawl 555 should have one file", 1, selector.getFilesForCrawl(555).size());
+
+    List<Integer> selectedIds = selector.getSelectedCrawlIds(127);
+    assertThat("selectedIds should contain 222, 333, and 555 when last known crawl is 127", selectedIds, hasItems(222, 333, 555));
+    assertFalse("selectedIds should not contain 111 when last known crawl is 127", selectedIds.contains(111));
   }
 
   @Test

--- a/test/edu/stanford/dlss/was/TestWasapiDownloader.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloader.java
@@ -46,77 +46,84 @@ public class TestWasapiDownloader {
   public void main_executesFileSetRequest_usesAllAppropArgsSettings() throws Exception {
     String[] args = {"--collectionId", "123", "--jobId=456", "--crawlStartAfter", "2014-03-14", "--crawlStartBefore=2017-03-14", "--username=Fred" };
     WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
-    Mockito.when(mockConn.jsonQuery(anyString())).thenReturn(null);
+    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(null);
     WasapiDownloader downloaderSpy = PowerMockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, args));
     PowerMockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
     PowerMockito.whenNew(WasapiDownloader.class).withAnyArguments().thenReturn(downloaderSpy);
 
     WasapiDownloader.main(args);
-    verify(mockConn).jsonQuery(ArgumentMatchers.contains("collection=123"));
-    verify(mockConn).jsonQuery(ArgumentMatchers.contains("crawl=456"));
-    verify(mockConn).jsonQuery(ArgumentMatchers.contains("crawl-start-after=2014-03-14"));
-    verify(mockConn).jsonQuery(ArgumentMatchers.contains("crawl-start-before=2017-03-14"));
+    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("collection=123"));
+    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("crawl=456"));
+    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-after=2014-03-14"));
+    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-before=2017-03-14"));
     // username is used in login request
-    verify(mockConn, Mockito.never()).jsonQuery(ArgumentMatchers.contains("username=Fred"));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("username=Fred"));
     // output directory is not part of wasapi request
-    verify(mockConn, Mockito.never()).jsonQuery(ArgumentMatchers.contains(WasapiDownloaderSettings.OUTPUT_BASE_DIR_PARAM_NAME));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains(WasapiDownloaderSettings.OUTPUT_BASE_DIR_PARAM_NAME));
   }
 
   @Test
   public void main_executesFileSetRequest_onlyUsesArgsSettings() throws Exception {
     String[] args = {"--collectionId", "123" };
     WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
-    Mockito.when(mockConn.jsonQuery(anyString())).thenReturn(null);
+    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(null);
     WasapiDownloader downloaderSpy = PowerMockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, args));
     PowerMockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
     PowerMockito.whenNew(WasapiDownloader.class).withAnyArguments().thenReturn(downloaderSpy);
 
     WasapiDownloader.main(args);
-    verify(mockConn).jsonQuery(ArgumentMatchers.contains("collection=123"));
-    verify(mockConn, Mockito.never()).jsonQuery(ArgumentMatchers.contains("crawl="));
-    verify(mockConn, Mockito.never()).jsonQuery(ArgumentMatchers.contains("crawl-start-after="));
-    verify(mockConn, Mockito.never()).jsonQuery(ArgumentMatchers.contains("crawl-start-before="));
+    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("collection=123"));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl="));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-after="));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-before="));
   }
 
   @Test
   public void main_singleFileDownload_onlyUsesFilename() throws Exception {
     String[] args = {"--collectionId", "123", "--filename", "ARCHIVEIT-5425-MONTHLY-JOB302671-20170526114117181-00049.warc.gz" };
     WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
-    Mockito.when(mockConn.jsonQuery(anyString())).thenReturn(null);
+    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(null);
     WasapiDownloader downloaderSpy = PowerMockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, args));
     PowerMockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
     PowerMockito.whenNew(WasapiDownloader.class).withAnyArguments().thenReturn(downloaderSpy);
 
     WasapiDownloader.main(args);
-    verify(mockConn).jsonQuery(ArgumentMatchers.contains("filename=ARCHIVEIT-5425-MONTHLY-JOB302671-20170526114117181-00049.warc.gz"));
-    verify(mockConn, Mockito.never()).jsonQuery(ArgumentMatchers.contains("crawl="));
-    verify(mockConn, Mockito.never()).jsonQuery(ArgumentMatchers.contains("crawl-start-after="));
-    verify(mockConn, Mockito.never()).jsonQuery(ArgumentMatchers.contains("crawl-start-before="));
-    verify(mockConn, Mockito.never()).jsonQuery(ArgumentMatchers.contains("collection="));
+    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("filename=ARCHIVEIT-5425-MONTHLY-JOB302671-20170526114117181-00049.warc.gz"));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl="));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-after="));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-before="));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("collection="));
   }
 
   @Test
   public void downloadSelectedWarcs_requestsFileSetResponse() throws Exception {
     WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
-    Mockito.when(mockConn.jsonQuery(anyString())).thenReturn(null);
+    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(null);
     WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
     Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
 
     downloaderSpy.downloadSelectedWarcs();
     WasapiDownloaderSettings mySettings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, null);
-    verify(mockConn).jsonQuery(ArgumentMatchers.startsWith(mySettings.baseUrlString()));
+    verify(mockConn).pagedJsonQuery(ArgumentMatchers.startsWith(mySettings.baseUrlString()));
+  }
+
+  private List<WasapiResponse> getWasapiRespList() {
+    List<WasapiResponse> wasapiRespList = new ArrayList<WasapiResponse>();
+    wasapiRespList.add(new WasapiResponse());
+    return wasapiRespList;
   }
 
   @Test
   public void downloadSelectedWarcs_usesCrawlSelector() throws Exception {
     WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
-    Mockito.when(mockConn.jsonQuery(anyString())).thenReturn(new WasapiResponse());
+    List<WasapiResponse> wasapiRespList = getWasapiRespList();
+    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(wasapiRespList);
 
     WasapiCrawlSelector mockCrawlSelector = PowerMockito.mock(WasapiCrawlSelector.class);
     List<Integer> desiredCrawlIds = new ArrayList<Integer>();
     desiredCrawlIds.add(Integer.valueOf("666"));
     PowerMockito.when(mockCrawlSelector.getSelectedCrawlIds(0)).thenReturn(desiredCrawlIds);
-    PowerMockito.whenNew(WasapiCrawlSelector.class).withAnyArguments().thenReturn(mockCrawlSelector);
+    PowerMockito.whenNew(WasapiCrawlSelector.class).withArguments(wasapiRespList).thenReturn(mockCrawlSelector);
 
     WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
     Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
@@ -133,10 +140,11 @@ public class TestWasapiDownloader {
     String[] args = { "--jobIdLowerBound=" + argValue };
 
     WasapiCrawlSelector mockCrawlSelector = PowerMockito.mock(WasapiCrawlSelector.class);
-    PowerMockito.whenNew(WasapiCrawlSelector.class).withAnyArguments().thenReturn(mockCrawlSelector);
+    List<WasapiResponse> wasapiRespList = getWasapiRespList();
+    PowerMockito.whenNew(WasapiCrawlSelector.class).withArguments(wasapiRespList).thenReturn(mockCrawlSelector);
 
     WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
-    Mockito.when(mockConn.jsonQuery(anyString())).thenReturn(new WasapiResponse());
+    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(wasapiRespList);
     WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, args));
     Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
 


### PR DESCRIPTION
the original issue suggested a single `WasapiFile[]` array, but this implementation takes a slightly different approach:  it adds `WasapiConnection.pagedJsonQuery` to return a list of responses for the available result pages (by following each next link), and it adds a `WasapiCrawlSelector` constructor that takes a list of `WasapiResponse` objects, aggregating the file lists from each response into the selector.  selector then gets used as before.  i tried to have the commits build on one another logically.

closes #30 