### PR TITLE
Add single file download.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,9 @@ Download all crawl files created after 2014:
 Download crawl files created before 2012, into /tmp/:
 
 `./build/install/wasapi-downloader/bin/wasapi-downloader --crawlStartBefore 2012-01-01 --outputBaseDir /tmp/`
+
+Download a single file:
+
+`./build/install/wasapi-downloader/bin/wasapi-downloader --filename ARCHIVEIT-5425-MONTHLY-JOB302671-20170526114117181-00049.warc.gz`
+
+**Note:** When a `--filename` argument is present, all other request parameters (crawl start/end, collection ID, job ID) are ignored.

--- a/src/edu/stanford/dlss/was/WasapiDownloader.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloader.java
@@ -76,6 +76,13 @@ public class WasapiDownloader {
 
   private List<String> requestParams() {
     List<String> params = new ArrayList<String>();
+
+    // If a filename is provided, other arguments are ignored
+    if (settings.filename() != null) {
+      params.add("filename=" + settings.filename());
+      return params;
+    }
+
     if (settings.collectionId() != null)
       params.add("collection=" + settings.collectionId());
     if (settings.crawlStartAfter() != null)

--- a/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
@@ -41,6 +41,7 @@ public class WasapiDownloaderSettings {
   public static final String CRAWL_START_BEFORE_PARAM_NAME = "crawlStartBefore";
   public static final String JOB_ID_LOWER_BOUND_PARAM_NAME = "jobIdLowerBound";
   public static final String OUTPUT_BASE_DIR_PARAM_NAME = "outputBaseDir";
+  public static final String FILENAME_PARAM_NAME = "filename";
 
   private HelpFormatter helpFormatter;
   private static Options wdsOpts;
@@ -59,7 +60,8 @@ public class WasapiDownloaderSettings {
     buildArgOption(CRAWL_START_AFTER_PARAM_NAME, "only download crawl files created after this date"),
     buildArgOption(CRAWL_START_BEFORE_PARAM_NAME, "only download crawl files created before this date"),
     buildArgOption(JOB_ID_LOWER_BOUND_PARAM_NAME, "\"last crawl downloaded\": only download crawl files with a higher job ID (not inclusive)"),
-    buildArgOption(OUTPUT_BASE_DIR_PARAM_NAME, "destination directory for downloaded WARC files")
+    buildArgOption(OUTPUT_BASE_DIR_PARAM_NAME, "destination directory for downloaded WARC files"),
+    buildArgOption(FILENAME_PARAM_NAME, "single filename to download")
   };
 
   static {
@@ -132,6 +134,10 @@ public class WasapiDownloaderSettings {
 
   public String outputBaseDir() {
     return settings.getProperty(OUTPUT_BASE_DIR_PARAM_NAME);
+  }
+
+  public String filename() {
+    return settings.getProperty(FILENAME_PARAM_NAME);
   }
 
   public String getHelpAndSettingsMessage() {

--- a/test/edu/stanford/dlss/was/TestWasapiDownloader.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloader.java
@@ -79,6 +79,23 @@ public class TestWasapiDownloader {
   }
 
   @Test
+  public void main_singleFileDownload_onlyUsesFilename() throws Exception {
+    String[] args = {"--collectionId", "123", "--filename", "ARCHIVEIT-5425-MONTHLY-JOB302671-20170526114117181-00049.warc.gz" };
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    Mockito.when(mockConn.jsonQuery(anyString())).thenReturn(null);
+    WasapiDownloader downloaderSpy = PowerMockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, args));
+    PowerMockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+    PowerMockito.whenNew(WasapiDownloader.class).withAnyArguments().thenReturn(downloaderSpy);
+
+    WasapiDownloader.main(args);
+    verify(mockConn).jsonQuery(ArgumentMatchers.contains("filename=ARCHIVEIT-5425-MONTHLY-JOB302671-20170526114117181-00049.warc.gz"));
+    verify(mockConn, Mockito.never()).jsonQuery(ArgumentMatchers.contains("crawl="));
+    verify(mockConn, Mockito.never()).jsonQuery(ArgumentMatchers.contains("crawl-start-after="));
+    verify(mockConn, Mockito.never()).jsonQuery(ArgumentMatchers.contains("crawl-start-before="));
+    verify(mockConn, Mockito.never()).jsonQuery(ArgumentMatchers.contains("collection="));
+  }
+
+  @Test
   public void downloadSelectedWarcs_requestsFileSetResponse() throws Exception {
     WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
     Mockito.when(mockConn.jsonQuery(anyString())).thenReturn(null);

--- a/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
@@ -45,7 +45,7 @@ public class TestWasapiDownloaderSettings {
     //TODO: if settings validation flags possibly nonsensical/redundant combos like jobId
     // and jobIdLowerBound, this test might have to be broken up a bit.
     String[] args = { "-h", "--collectionId", "123", "--jobId=456", "--jobIdLowerBound=400",
-        "--crawlStartAfter", "2014-03-14", "--crawlStartBefore=2017-03-14" };
+        "--crawlStartAfter", "2014-03-14", "--crawlStartBefore=2017-03-14", "--filename=filename.warc.gz" };
     WasapiDownloaderSettings settings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, args);
 
     String helpAndSettingsMsg = settings.getHelpAndSettingsMessage();
@@ -62,6 +62,7 @@ public class TestWasapiDownloaderSettings {
     assertThat("helpAndSettingsMsg lists help flag", helpAndSettingsMsg, containsString("-h,--help"));
     assertThat("helpAndSettingsMsg lists jobId arg", helpAndSettingsMsg, containsString("--jobId <arg>"));
     assertThat("helpAndSettingsMsg lists jobIdLowerBound arg", helpAndSettingsMsg, containsString("--jobIdLowerBound <arg>"));
+    assertThat("helpAndSettingsMsg lists filename arg", helpAndSettingsMsg, containsString("--filename <arg>"));
 
     assertThat("helpAndSettingsMsg hides password value", helpAndSettingsMsg, containsString("password : [password hidden]"));
     assertThat("helpAndSettingsMsg lists crawlStartAfter value", helpAndSettingsMsg, containsString("crawlStartAfter : 2014-03-14"));
@@ -74,6 +75,7 @@ public class TestWasapiDownloaderSettings {
     assertThat("helpAndSettingsMsg lists authurl value", helpAndSettingsMsg, containsString("authurl : https://example.org/login"));
     assertThat("helpAndSettingsMsg lists username value", helpAndSettingsMsg, containsString("username : user"));
     assertThat("helpAndSettingsMsg lists accountId value", helpAndSettingsMsg, containsString("accountId : 1"));
+    assertThat("helpAndSettingsMsg lists filename value", helpAndSettingsMsg, containsString("filename : filename.warc.gz"));
   }
 
   @Test


### PR DESCRIPTION
Closes #81 

I think this should integrate nicely with the branch that @ndushay is working on at the moment. This PR does the upfront work of building the single file download request, which should then get executed like any other request.