### PR TITLE
WasapiDownloader downloads and validates appropriate files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ bin/
 build.xml
 
 eclipse-bin/
+test/outputBaseDir/

--- a/src/edu/stanford/dlss/was/WasapiDownloader.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloader.java
@@ -103,11 +103,12 @@ public class WasapiDownloader {
     return outputPath + SEP + file.getFilename();
   }
 
-  private boolean checksumValidate(String algorithm, WasapiFile file, String fullFilePath) throws NoSuchAlgorithmException, IOException {
+  // package level method for testing
+  boolean checksumValidate(String algorithm, WasapiFile file, String fullFilePath) throws NoSuchAlgorithmException, IOException {
     // TODO:  use setting to decide md5 vs sha1 (see wasapi-downloader#92 in github)
     String checksum = file.getChecksums().get(algorithm);
     if (checksum == null) {
-      System.err.println("No checksum of type: " + algorithm + " available.  Options are " + file.getChecksums().keySet().toString());
+      System.err.println("No checksum of type: " + algorithm + " available: " + file.getChecksums().toString());
       return false;
     }
 
@@ -115,7 +116,10 @@ public class WasapiDownloader {
       return WasapiValidator.validateMd5(checksum, fullFilePath);
     else if ("sha1".equals(algorithm))
       return WasapiValidator.validateSha1(checksum, fullFilePath);
-    return false;
+    else {
+      System.err.println("Unsupported checksum algorithm: " + algorithm + ".  Options are 'md5' or 'sha1'");
+      return false;
+    }
   }
 
   private List<Integer> desiredCrawlIds(WasapiCrawlSelector crawlSelector) {

--- a/src/edu/stanford/dlss/was/WasapiDownloader.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloader.java
@@ -1,13 +1,22 @@
 package edu.stanford.dlss.was;
 
+import java.io.File;
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.validator.routines.IntegerValidator;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpResponseException;
 
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
 public class WasapiDownloader {
   public static final String SETTINGS_FILE_LOCATION = "config/settings.properties";
+  private static final char SEP = File.separatorChar;
+
+  // TODO:  use setting (see wasapi-downloader#93 in github)
+  public static final int NUM_RETRIES = 3;
 
   public WasapiDownloaderSettings settings;
 
@@ -18,13 +27,29 @@ public class WasapiDownloader {
     settings = new WasapiDownloaderSettings(settingsFileLocation, args);
   }
 
-  public void executeFromCmdLine() throws IOException {
+  public void executeFromCmdLine() throws IOException, NoSuchAlgorithmException {
     if (settings.shouldDisplayHelp()) {
       System.out.print(settings.getHelpAndSettingsMessage());
       return;
     }
 
     downloadSelectedWarcs();
+  }
+
+  // package level method for testing
+  void downloadSelectedWarcs() throws IOException, NoSuchAlgorithmException {
+    // System.out.println("DEBUG: about to request " + getFileSetRequestUrl());
+    List<WasapiResponse> wasapiRespList = getWasapiConn().pagedJsonQuery(getFileSetRequestUrl());
+    // System.out.println(wasapiResp.toString());
+
+    if (wasapiRespList != null && wasapiRespList.get(0) != null) {
+      WasapiCrawlSelector crawlSelector = new WasapiCrawlSelector(wasapiRespList);
+      for (Integer crawlId : desiredCrawlIds(crawlSelector)) {
+        for (WasapiFile file : crawlSelector.getFilesForCrawl(crawlId)) {
+          downloadAndValidateFile(file);
+        }
+      }
+    }
   }
 
   // package level method for testing
@@ -35,20 +60,62 @@ public class WasapiDownloader {
   }
 
   // package level method for testing
-  void downloadSelectedWarcs() throws IOException {
-    // System.out.println("DEBUG: about to request " + getFileSetRequestUrl());
-    List<WasapiResponse> wasapiRespList = getWasapiConn().pagedJsonQuery(getFileSetRequestUrl());
-    // System.out.println(wasapiResp.toString());
-
-    if (wasapiRespList != null && wasapiRespList.get(0) != null) {
-      WasapiCrawlSelector crawlSelector = new WasapiCrawlSelector(wasapiRespList);
-      for (Integer crawlId : desiredCrawlIds(crawlSelector)) {
-        for (WasapiFile file : crawlSelector.getFilesForCrawl(crawlId)) {
-          // TODO:  make a separate method for downloading individual file?
-          System.out.println("We will eventually download " + file.toString());
+  @SuppressWarnings("checkstyle:MethodLength")
+  void downloadAndValidateFile(WasapiFile file) throws NoSuchAlgorithmException {
+    String fullFilePath = prepareOutputLocation(file);
+    int attempts = 0;
+    boolean notValidated = true;
+    do {
+      attempts++;
+      try {
+        // System.out.println("DEBUG: trying to get " + file.getLocations()[0]);
+        boolean downloadSuccess = getWasapiConn().downloadQuery(file.getLocations()[0], fullFilePath);
+        if (downloadSuccess && checksumValidate("md5", file, fullFilePath)) {
+          System.out.println("file retrieved successfully: " + file.getLocations()[0]);
+          notValidated = false; // break out of loop
         }
+      } catch (HttpResponseException e) {
+        System.err.println("ERROR: HttpResponseException downloading file (will not retry) " + fullFilePath);
+        System.err.println(" HTTP ResponseCode is " + e.getStatusCode());
+        e.printStackTrace(System.err);
+        attempts = NUM_RETRIES + 1;  // no more attempts
+      } catch (ClientProtocolException e) {
+        System.err.println("ERROR: ClientProtocolException downloading file (will not retry) " + fullFilePath);
+        e.printStackTrace(System.err);
+        attempts = NUM_RETRIES + 1;  // no more attempts
+      } catch (IOException e) {
+        // swallow exception and try again - it may be a network issue
+        System.err.println("WARNING: exception downloading file (will retry) " + fullFilePath);
+        e.printStackTrace(System.err);
       }
+    } while (attempts <= NUM_RETRIES && notValidated);
+
+    if (attempts == NUM_RETRIES)
+      System.err.println("file not retrieved: " + file.getLocations()[0]);
+    else if (notValidated)
+      System.err.println("file has invalid checksum: " + file.getLocations()[0]);
+  }
+
+  // package level method for testing
+  String prepareOutputLocation(WasapiFile file) {
+    String outputPath = settings.outputBaseDir() + "AIT_" + file.getCollectionId() + SEP + file.getCrawlId() + SEP + file.getCrawlStartDateStr();
+    new File(outputPath).mkdirs();
+    return outputPath + SEP + file.getFilename();
+  }
+
+  private boolean checksumValidate(String algorithm, WasapiFile file, String fullFilePath) throws NoSuchAlgorithmException, IOException {
+    // TODO:  use setting to decide md5 vs sha1 (see wasapi-downloader#92 in github)
+    String checksum = file.getChecksums().get(algorithm);
+    if (checksum == null) {
+      System.err.println("No checksum of type: " + algorithm + " available.  Options are " + file.getChecksums().keySet().toString());
+      return false;
     }
+
+    if ("md5".equals(algorithm))
+      return WasapiValidator.validateMd5(checksum, fullFilePath);
+    else if ("sha1".equals(algorithm))
+      return WasapiValidator.validateSha1(checksum, fullFilePath);
+    return false;
   }
 
   private List<Integer> desiredCrawlIds(WasapiCrawlSelector crawlSelector) {
@@ -95,7 +162,7 @@ public class WasapiDownloader {
   }
 
   @SuppressWarnings("checkstyle:UncommentedMain")
-  public static void main(String[] args) throws SettingsLoadException, IOException {
+  public static void main(String[] args) throws SettingsLoadException, IOException, NoSuchAlgorithmException {
     WasapiDownloader downloader = new WasapiDownloader(SETTINGS_FILE_LOCATION, args);
     downloader.executeFromCmdLine();
   }

--- a/test/edu/stanford/dlss/was/TestWasapiDownloader.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloader.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.ArgumentMatchers.*;
 
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,7 +38,7 @@ public class TestWasapiDownloader {
 
   @Test
   @SuppressWarnings("checkstyle:NoWhitespaceAfter")
-  public void main_withHelp_canExecuteWithoutCrashing() throws SettingsLoadException, IOException {
+  public void main_withHelp_canExecuteWithoutCrashing() throws SettingsLoadException, IOException, NoSuchAlgorithmException {
     String[] args = { "-h" };
     WasapiDownloader.main(args);
   }

--- a/test/edu/stanford/dlss/was/TestWasapiDownloader.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloader.java
@@ -4,10 +4,13 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.ArgumentMatchers.*;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import org.junit.*;
@@ -19,7 +22,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(WasapiDownloader.class)
+@PrepareForTest({WasapiDownloader.class, WasapiValidator.class})
 public class TestWasapiDownloader {
 
   @Test
@@ -225,5 +228,73 @@ public class TestWasapiDownloader {
 
     wd.prepareOutputLocation(wfile);
     assertTrue("Directory should exist: " + expected, expectedDir.exists());
+  }
+
+  @Test
+  public void checksumValidate_md5_calls_wasapiValidator_validateMd5() throws SettingsLoadException, NoSuchAlgorithmException, IOException {
+    WasapiFile wfile = new WasapiFile();
+    String expectedChecksum = "666";
+    HashMap<String, String> checksumsMap = new HashMap<String, String>();
+    checksumsMap.put("md5", expectedChecksum);
+    wfile.setChecksums(checksumsMap);
+
+    PowerMockito.mockStatic(WasapiValidator.class);
+    Mockito.when(WasapiValidator.validateMd5(expectedChecksum, anyString())).thenReturn(anyBoolean());
+
+    WasapiDownloader wd = new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null);
+    wd.checksumValidate("md5", wfile, anyString());
+
+    PowerMockito.verifyStatic();
+    WasapiValidator.validateMd5(expectedChecksum, "");
+  }
+
+  @Test
+  public void checksumValidate_sha1_calls_wasapiValidator_validateSha1() throws SettingsLoadException, NoSuchAlgorithmException, IOException {
+    WasapiFile wfile = new WasapiFile();
+    String expectedChecksum = "666";
+    HashMap<String, String> checksumsMap = new HashMap<String, String>();
+    checksumsMap.put("sha1", expectedChecksum);
+    wfile.setChecksums(checksumsMap);
+
+    PowerMockito.mockStatic(WasapiValidator.class);
+    Mockito.when(WasapiValidator.validateSha1(expectedChecksum, anyString())).thenReturn(anyBoolean());
+
+    WasapiDownloader wd = new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null);
+    wd.checksumValidate("sha1", wfile, anyString());
+
+    PowerMockito.verifyStatic();
+    WasapiValidator.validateSha1(expectedChecksum, "");
+  }
+
+  @Test
+  public void checksumValidate_missingChecksumPrintsErrorAndReturnsFalse() throws SettingsLoadException, NoSuchAlgorithmException, IOException {
+    WasapiFile wfile = new WasapiFile();
+    String expectedChecksum = "666";
+    HashMap<String, String> checksumsMap = new HashMap<String, String>();
+    checksumsMap.put("sha1", expectedChecksum);
+    wfile.setChecksums(checksumsMap);
+
+    ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(errContent));
+
+    WasapiDownloader wd = new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null);
+    assertFalse("result of checksumValidate for missing checksum should be false", wd.checksumValidate("md5", wfile, any()));
+    assertEquals("Wrong SYSERR output", "No checksum of type: md5 available: {sha1=666}\n", errContent.toString());
+  }
+
+  @Test
+  public void checksumValidate_unsupportedAlgorithmReturnsFalse() throws SettingsLoadException, NoSuchAlgorithmException, IOException {
+    WasapiFile wfile = new WasapiFile();
+    String expectedChecksum = "666";
+    HashMap<String, String> checksumsMap = new HashMap<String, String>();
+    checksumsMap.put("foo", expectedChecksum);
+    wfile.setChecksums(checksumsMap);
+
+    ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(errContent));
+
+    WasapiDownloader wd = new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null);
+    assertFalse("result of checksumValidate for unsupported algorithm should be false", wd.checksumValidate("foo", wfile, any()));
+    assertEquals("Wrong SYSERR output", "Unsupported checksum algorithm: foo.  Options are 'md5' or 'sha1'\n", errContent.toString());
   }
 }

--- a/test/edu/stanford/dlss/was/TestWasapiDownloader.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloader.java
@@ -139,6 +139,7 @@ public class TestWasapiDownloader {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:MethodLength")
   public void downloadSelectedWarcs_callsDownloadAndValidateFile() throws Exception {
     WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
     Mockito.when(mockConn.jsonQuery(anyString())).thenReturn(new WasapiResponse());

--- a/test/edu/stanford/dlss/was/TestWasapiDownloader.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloader.java
@@ -9,20 +9,17 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 
 import org.junit.*;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({WasapiDownloader.class, WasapiValidator.class})
+/**
+ * Tests for WasapiDownloader that do NOT require PowerMock
+ *   We split out the PowerMock tets because jacoco at this time (2017-05-31) is unable to record coverage for
+ *   PowerMock tests.  Thus, this splitting lets us get coverage stats for WasapiDownloader for those tests that don't need PowerMock
+ */
 public class TestWasapiDownloader {
 
   @Test
@@ -32,72 +29,10 @@ public class TestWasapiDownloader {
   }
 
   @Test
-  public void main_callsExecutFromCmdLine() throws Exception {
-    WasapiDownloader mockDownloader = PowerMockito.mock(WasapiDownloader.class);
-    PowerMockito.whenNew(WasapiDownloader.class).withAnyArguments().thenReturn(mockDownloader);
-
-    WasapiDownloader.main(null);
-    verify(mockDownloader).executeFromCmdLine();
-  }
-
-  @Test
   @SuppressWarnings("checkstyle:NoWhitespaceAfter")
   public void main_withHelp_canExecuteWithoutCrashing() throws SettingsLoadException, IOException, NoSuchAlgorithmException {
     String[] args = { "-h" };
     WasapiDownloader.main(args);
-  }
-
-  @Test
-  public void main_executesFileSetRequest_usesAllAppropArgsSettings() throws Exception {
-    String[] args = {"--collectionId", "123", "--jobId=456", "--crawlStartAfter", "2014-03-14", "--crawlStartBefore=2017-03-14", "--username=Fred" };
-    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
-    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(null);
-    WasapiDownloader downloaderSpy = PowerMockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, args));
-    PowerMockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
-    PowerMockito.whenNew(WasapiDownloader.class).withAnyArguments().thenReturn(downloaderSpy);
-
-    WasapiDownloader.main(args);
-    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("collection=123"));
-    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("crawl=456"));
-    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-after=2014-03-14"));
-    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-before=2017-03-14"));
-    // username is used in login request
-    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("username=Fred"));
-    // output directory is not part of wasapi request
-    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains(WasapiDownloaderSettings.OUTPUT_BASE_DIR_PARAM_NAME));
-  }
-
-  @Test
-  public void main_executesFileSetRequest_onlyUsesArgsSettings() throws Exception {
-    String[] args = {"--collectionId", "123" };
-    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
-    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(null);
-    WasapiDownloader downloaderSpy = PowerMockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, args));
-    PowerMockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
-    PowerMockito.whenNew(WasapiDownloader.class).withAnyArguments().thenReturn(downloaderSpy);
-
-    WasapiDownloader.main(args);
-    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("collection=123"));
-    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl="));
-    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-after="));
-    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-before="));
-  }
-
-  @Test
-  public void main_singleFileDownload_onlyUsesFilename() throws Exception {
-    String[] args = {"--collectionId", "123", "--filename", "ARCHIVEIT-5425-MONTHLY-JOB302671-20170526114117181-00049.warc.gz" };
-    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
-    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(null);
-    WasapiDownloader downloaderSpy = PowerMockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, args));
-    PowerMockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
-    PowerMockito.whenNew(WasapiDownloader.class).withAnyArguments().thenReturn(downloaderSpy);
-
-    WasapiDownloader.main(args);
-    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("filename=ARCHIVEIT-5425-MONTHLY-JOB302671-20170526114117181-00049.warc.gz"));
-    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl="));
-    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-after="));
-    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-before="));
-    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("collection="));
   }
 
   @Test
@@ -110,77 +45,6 @@ public class TestWasapiDownloader {
     downloaderSpy.downloadSelectedWarcs();
     WasapiDownloaderSettings mySettings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, null);
     verify(mockConn).pagedJsonQuery(ArgumentMatchers.startsWith(mySettings.baseUrlString()));
-  }
-
-  private List<WasapiResponse> getWasapiRespList() {
-    List<WasapiResponse> wasapiRespList = new ArrayList<WasapiResponse>();
-    wasapiRespList.add(new WasapiResponse());
-    return wasapiRespList;
-  }
-
-  @Test
-  public void downloadSelectedWarcs_usesCrawlSelector() throws Exception {
-    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
-    List<WasapiResponse> wasapiRespList = getWasapiRespList();
-    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(wasapiRespList);
-
-    WasapiCrawlSelector mockCrawlSelector = PowerMockito.mock(WasapiCrawlSelector.class);
-    List<Integer> desiredCrawlIds = new ArrayList<Integer>();
-    desiredCrawlIds.add(Integer.valueOf("666"));
-    PowerMockito.when(mockCrawlSelector.getSelectedCrawlIds(0)).thenReturn(desiredCrawlIds);
-    PowerMockito.whenNew(WasapiCrawlSelector.class).withArguments(wasapiRespList).thenReturn(mockCrawlSelector);
-
-    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
-    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
-
-    downloaderSpy.downloadSelectedWarcs();
-    verify(mockCrawlSelector).getSelectedCrawlIds(0); // no command line args means it gets all crawl ids like this
-    verify(mockCrawlSelector).getFilesForCrawl(anyInt());
-  }
-
-  @Test
-  @SuppressWarnings("checkstyle:MethodLength")
-  public void downloadSelectedWarcs_callsDownloadAndValidateFile() throws Exception {
-    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
-    Mockito.when(mockConn.jsonQuery(anyString())).thenReturn(new WasapiResponse());
-
-    WasapiCrawlSelector mockCrawlSelector = PowerMockito.mock(WasapiCrawlSelector.class);
-    List<Integer> desiredCrawlIds = new ArrayList<Integer>();
-    desiredCrawlIds.add(Integer.valueOf("666"));
-    PowerMockito.when(mockCrawlSelector.getSelectedCrawlIds(0)).thenReturn(desiredCrawlIds);
-    List<WasapiFile> filesForCrawl = new ArrayList<WasapiFile>();
-    WasapiFile wfile = new WasapiFile();
-    String filename = "i_is_a_warc_file";
-    wfile.setFilename(filename);
-    filesForCrawl.add(wfile);
-    PowerMockito.when(mockCrawlSelector.getFilesForCrawl(666)).thenReturn(filesForCrawl);
-    PowerMockito.whenNew(WasapiCrawlSelector.class).withAnyArguments().thenReturn(mockCrawlSelector);
-
-    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
-    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
-    Mockito.doNothing().when(downloaderSpy).downloadAndValidateFile(wfile);
-
-    downloaderSpy.downloadSelectedWarcs();
-    verify(downloaderSpy).downloadAndValidateFile(wfile);
-  }
-
-  @Test
-  @SuppressWarnings("checkstyle:NoWhitespaceAfter")
-  public void downloadSelectedWarcs_byJobIdLowerBound() throws Exception {
-    String argValue = "666";
-    String[] args = { "--jobIdLowerBound=" + argValue };
-
-    WasapiCrawlSelector mockCrawlSelector = PowerMockito.mock(WasapiCrawlSelector.class);
-    List<WasapiResponse> wasapiRespList = getWasapiRespList();
-    PowerMockito.whenNew(WasapiCrawlSelector.class).withArguments(wasapiRespList).thenReturn(mockCrawlSelector);
-
-    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
-    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(wasapiRespList);
-    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, args));
-    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
-
-    downloaderSpy.downloadSelectedWarcs();
-    verify(mockCrawlSelector).getSelectedCrawlIds(Integer.valueOf(argValue));
   }
 
   @Test
@@ -232,42 +96,6 @@ public class TestWasapiDownloader {
   }
 
   @Test
-  public void checksumValidate_md5_calls_wasapiValidator_validateMd5() throws SettingsLoadException, NoSuchAlgorithmException, IOException {
-    WasapiFile wfile = new WasapiFile();
-    String expectedChecksum = "666";
-    HashMap<String, String> checksumsMap = new HashMap<String, String>();
-    checksumsMap.put("md5", expectedChecksum);
-    wfile.setChecksums(checksumsMap);
-
-    PowerMockito.mockStatic(WasapiValidator.class);
-    Mockito.when(WasapiValidator.validateMd5(expectedChecksum, anyString())).thenReturn(anyBoolean());
-
-    WasapiDownloader wd = new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null);
-    wd.checksumValidate("md5", wfile, anyString());
-
-    PowerMockito.verifyStatic();
-    WasapiValidator.validateMd5(expectedChecksum, "");
-  }
-
-  @Test
-  public void checksumValidate_sha1_calls_wasapiValidator_validateSha1() throws SettingsLoadException, NoSuchAlgorithmException, IOException {
-    WasapiFile wfile = new WasapiFile();
-    String expectedChecksum = "666";
-    HashMap<String, String> checksumsMap = new HashMap<String, String>();
-    checksumsMap.put("sha1", expectedChecksum);
-    wfile.setChecksums(checksumsMap);
-
-    PowerMockito.mockStatic(WasapiValidator.class);
-    Mockito.when(WasapiValidator.validateSha1(expectedChecksum, anyString())).thenReturn(anyBoolean());
-
-    WasapiDownloader wd = new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null);
-    wd.checksumValidate("sha1", wfile, anyString());
-
-    PowerMockito.verifyStatic();
-    WasapiValidator.validateSha1(expectedChecksum, "");
-  }
-
-  @Test
   public void checksumValidate_missingChecksumPrintsErrorAndReturnsFalse() throws SettingsLoadException, NoSuchAlgorithmException, IOException {
     WasapiFile wfile = new WasapiFile();
     String expectedChecksum = "666";
@@ -279,7 +107,7 @@ public class TestWasapiDownloader {
     System.setErr(new PrintStream(errContent));
 
     WasapiDownloader wd = new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null);
-    assertFalse("result of checksumValidate for missing checksum should be false", wd.checksumValidate("md5", wfile, any()));
+    assertFalse("result of checksumValidate for missing checksum should be false", wd.checksumValidate("md5", wfile, "fullFilePath"));
     assertEquals("Wrong SYSERR output", "No checksum of type: md5 available: {sha1=666}\n", errContent.toString());
   }
 
@@ -295,7 +123,7 @@ public class TestWasapiDownloader {
     System.setErr(new PrintStream(errContent));
 
     WasapiDownloader wd = new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null);
-    assertFalse("result of checksumValidate for unsupported algorithm should be false", wd.checksumValidate("foo", wfile, any()));
+    assertFalse("result of checksumValidate for unsupported algorithm should be false", wd.checksumValidate("foo", wfile, "fullFilePath"));
     assertEquals("Wrong SYSERR output", "Unsupported checksum algorithm: foo.  Options are 'md5' or 'sha1'\n", errContent.toString());
   }
 }

--- a/test/edu/stanford/dlss/was/TestWasapiDownloader.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloader.java
@@ -135,6 +135,31 @@ public class TestWasapiDownloader {
   }
 
   @Test
+  public void downloadSelectedWarcs_callsDownloadAndValidateFile() throws Exception {
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    Mockito.when(mockConn.jsonQuery(anyString())).thenReturn(new WasapiResponse());
+
+    WasapiCrawlSelector mockCrawlSelector = PowerMockito.mock(WasapiCrawlSelector.class);
+    List<Integer> desiredCrawlIds = new ArrayList<Integer>();
+    desiredCrawlIds.add(Integer.valueOf("666"));
+    PowerMockito.when(mockCrawlSelector.getSelectedCrawlIds(0)).thenReturn(desiredCrawlIds);
+    List<WasapiFile> filesForCrawl = new ArrayList<WasapiFile>();
+    WasapiFile wfile = new WasapiFile();
+    String filename = "i_is_a_warc_file";
+    wfile.setFilename(filename);
+    filesForCrawl.add(wfile);
+    PowerMockito.when(mockCrawlSelector.getFilesForCrawl(666)).thenReturn(filesForCrawl);
+    PowerMockito.whenNew(WasapiCrawlSelector.class).withAnyArguments().thenReturn(mockCrawlSelector);
+
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+    Mockito.doNothing().when(downloaderSpy).downloadAndValidateFile(wfile);
+
+    downloaderSpy.downloadSelectedWarcs();
+    verify(downloaderSpy).downloadAndValidateFile(wfile);
+  }
+
+  @Test
   @SuppressWarnings("checkstyle:NoWhitespaceAfter")
   public void downloadSelectedWarcs_byJobIdLowerBound() throws Exception {
     String argValue = "666";

--- a/test/edu/stanford/dlss/was/TestWasapiDownloader_DownloadAndValidateFile.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloader_DownloadAndValidateFile.java
@@ -1,0 +1,308 @@
+package edu.stanford.dlss.was;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static org.hamcrest.CoreMatchers.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.security.NoSuchAlgorithmException;
+
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpResponseException;
+import org.hamcrest.core.StringStartsWith;
+import org.junit.*;
+import org.mockito.Mockito;
+
+/**
+ * WasapiDownloader tests for downloadAndValidateFile() method
+ */
+@SuppressWarnings({"TypeName", "MethodLength"})
+public class TestWasapiDownloader_DownloadAndValidateFile {
+
+  @Test
+  public void downloadAndValidateFile_callsPrepareOutpuLocation() throws NoSuchAlgorithmException, SettingsLoadException {
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    WasapiFile wfile = new WasapiFile();
+    Mockito.doReturn(null).when(downloaderSpy).prepareOutputLocation(wfile);
+
+    downloaderSpy.downloadAndValidateFile(wfile);
+    verify(downloaderSpy).prepareOutputLocation(wfile);
+  }
+
+  @Test
+  public void downloadAndValidateFile_printsErrorForNullOutpuLocation() throws NoSuchAlgorithmException, SettingsLoadException {
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    WasapiFile wfile = new WasapiFile();
+    Mockito.doReturn(null).when(downloaderSpy).prepareOutputLocation(wfile);
+
+    ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(errContent));
+
+    downloaderSpy.downloadAndValidateFile(wfile);
+    assertEquals("Wrong SYSERR output", "fullFilePath is null - can't retrieve file\n", errContent.toString());
+  }
+
+  @Test
+  public void downloadAndValidateFile_callsDownloadQuery() throws Exception {
+    WasapiFile wfile = new WasapiFile();
+    String firstLocation = "out there";
+    String[] locations = new String[]{firstLocation, "another location"};
+    wfile.setLocations(locations);
+    String fullFilePath = "somewhere";
+
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    Mockito.when(mockConn.downloadQuery(firstLocation, fullFilePath)).thenReturn(false);
+
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    Mockito.doReturn(fullFilePath).when(downloaderSpy).prepareOutputLocation(wfile);
+    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+
+    downloaderSpy.downloadAndValidateFile(wfile);
+    verify(mockConn, atLeastOnce()).downloadQuery(firstLocation, fullFilePath);
+  }
+
+  @Test
+  public void downloadAndValidateFile_callsChecksumValidate() throws Exception {
+    WasapiFile wfile = new WasapiFile();
+    String firstLocation = "out there";
+    String[] locations = new String[]{firstLocation};
+    wfile.setLocations(locations);
+    String fullFilePath = "somewhere";
+
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    Mockito.when(mockConn.downloadQuery(firstLocation, fullFilePath)).thenReturn(true);
+
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    Mockito.doReturn(fullFilePath).when(downloaderSpy).prepareOutputLocation(wfile);
+    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+    Mockito.doReturn(false).when(downloaderSpy).checksumValidate("md5", wfile, fullFilePath);
+
+    downloaderSpy.downloadAndValidateFile(wfile);
+    verify(downloaderSpy, atLeastOnce()).checksumValidate("md5", wfile, fullFilePath);
+  }
+
+  @Test
+  public void downloadAndValidateFile_success() throws Exception {
+    WasapiFile wfile = new WasapiFile();
+    String firstLocation = "out there";
+    String[] locations = new String[]{firstLocation};
+    wfile.setLocations(locations);
+    String fullFilePath = "somewhere";
+
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    Mockito.when(mockConn.downloadQuery(firstLocation, fullFilePath)).thenReturn(true);
+
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    Mockito.doReturn(fullFilePath).when(downloaderSpy).prepareOutputLocation(wfile);
+    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+    Mockito.doReturn(true).when(downloaderSpy).checksumValidate("md5", wfile, fullFilePath);
+
+    ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(outContent));
+    ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(errContent));
+
+    downloaderSpy.downloadAndValidateFile(wfile);
+    verify(mockConn, times(1)).downloadQuery(firstLocation, fullFilePath);
+    verify(downloaderSpy, times(1)).checksumValidate("md5", wfile, fullFilePath);
+    assertEquals("Wrong SYSOUT output", "file retrieved successfully: " + firstLocation + "\n", outContent.toString());
+    assertEquals("No SYSERR output for success", "", errContent.toString());
+  }
+
+  @Test
+  public void downloadAndValidateFile_downloadFailsThenSucceeds() throws Exception {
+    WasapiFile wfile = new WasapiFile();
+    String firstLocation = "out there";
+    String[] locations = new String[]{firstLocation};
+    wfile.setLocations(locations);
+    String fullFilePath = "somewhere";
+
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    Mockito.when(mockConn.downloadQuery(firstLocation, fullFilePath)).thenReturn(false, false, false, true);
+
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    Mockito.doReturn(fullFilePath).when(downloaderSpy).prepareOutputLocation(wfile);
+    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+    Mockito.doReturn(true).when(downloaderSpy).checksumValidate("md5", wfile, fullFilePath);
+
+    downloaderSpy.downloadAndValidateFile(wfile);
+    verify(mockConn, times(WasapiDownloader.NUM_RETRIES + 1)).downloadQuery(firstLocation, fullFilePath);
+    verify(downloaderSpy, times(1)).checksumValidate("md5", wfile, fullFilePath);
+  }
+
+  @Test
+  public void downloadAndValidateFile_validationFailsThenSucceeds() throws Exception {
+    WasapiFile wfile = new WasapiFile();
+    String firstLocation = "out there";
+    String[] locations = new String[]{firstLocation};
+    wfile.setLocations(locations);
+    String fullFilePath = "somewhere";
+
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    Mockito.when(mockConn.downloadQuery(firstLocation, fullFilePath)).thenReturn(true);
+
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    Mockito.doReturn(fullFilePath).when(downloaderSpy).prepareOutputLocation(wfile);
+    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+    Mockito.doReturn(false, false, false, true).when(downloaderSpy).checksumValidate("md5", wfile, fullFilePath);
+
+    downloaderSpy.downloadAndValidateFile(wfile);
+    verify(mockConn, times(WasapiDownloader.NUM_RETRIES + 1)).downloadQuery(firstLocation, fullFilePath);
+    verify(downloaderSpy, times(WasapiDownloader.NUM_RETRIES + 1)).checksumValidate("md5", wfile, fullFilePath);
+  }
+
+  @Test
+  public void downloadAndValidateFile_downloadFailsThenValidationFails() throws Exception{
+    // checksum won't validate, then download doesn't work, but 3rd time both work
+    WasapiFile wfile = new WasapiFile();
+    String firstLocation = "out there";
+    String[] locations = new String[]{firstLocation};
+    wfile.setLocations(locations);
+    String fullFilePath = "somewhere";
+
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    Mockito.when(mockConn.downloadQuery(firstLocation, fullFilePath)).thenReturn(true, false, true);
+
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    Mockito.doReturn(fullFilePath).when(downloaderSpy).prepareOutputLocation(wfile);
+    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+    Mockito.doReturn(false, true).when(downloaderSpy).checksumValidate("md5", wfile, fullFilePath);
+
+    downloaderSpy.downloadAndValidateFile(wfile);
+    verify(mockConn, times(3)).downloadQuery(firstLocation, fullFilePath);
+    verify(downloaderSpy, times(2)).checksumValidate("md5", wfile, fullFilePath);
+  }
+
+  @Test
+  public void downloadAndValidateFile_downloadNeverSucceeds() throws Exception {
+    WasapiFile wfile = new WasapiFile();
+    String firstLocation = "out there";
+    String[] locations = new String[]{firstLocation};
+    wfile.setLocations(locations);
+    String fullFilePath = "somewhere";
+
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    Mockito.when(mockConn.downloadQuery(firstLocation, fullFilePath)).thenReturn(false, false, false, false);
+
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    Mockito.doReturn(fullFilePath).when(downloaderSpy).prepareOutputLocation(wfile);
+    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+
+    ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(errContent));
+
+    downloaderSpy.downloadAndValidateFile(wfile);
+    verify(mockConn, times(WasapiDownloader.NUM_RETRIES + 1)).downloadQuery(firstLocation, fullFilePath);
+    verify(downloaderSpy, never()).checksumValidate("md5", wfile, fullFilePath);
+    assertEquals("Wrong SYSERR output", "file not retrieved or unable to validate checksum: " + firstLocation + "\n", errContent.toString());
+  }
+
+  @Test
+  public void downloadAndValidateFile_checksumNeverValidates() throws Exception {
+    WasapiFile wfile = new WasapiFile();
+    String firstLocation = "out there";
+    String[] locations = new String[]{firstLocation};
+    wfile.setLocations(locations);
+    String fullFilePath = "somewhere";
+
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    Mockito.when(mockConn.downloadQuery(firstLocation, fullFilePath)).thenReturn(true, true, true, true);
+
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    Mockito.doReturn(fullFilePath).when(downloaderSpy).prepareOutputLocation(wfile);
+    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+    Mockito.doReturn(false).when(downloaderSpy).checksumValidate("md5", wfile, fullFilePath);
+
+    ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(errContent));
+
+    downloaderSpy.downloadAndValidateFile(wfile);
+    verify(mockConn, times(WasapiDownloader.NUM_RETRIES + 1)).downloadQuery(firstLocation, fullFilePath);
+    verify(downloaderSpy, times(WasapiDownloader.NUM_RETRIES + 1)).checksumValidate("md5", wfile, fullFilePath);
+    assertEquals("Wrong SYSERR output", "file not retrieved or unable to validate checksum: " + firstLocation + "\n", errContent.toString());
+  }
+
+  @Test
+  public void downloadAndValidateFile_HttpResponseException_handled() throws IOException, SettingsLoadException, NoSuchAlgorithmException {
+    WasapiFile wfile = new WasapiFile();
+    String firstLocation = "out there";
+    String[] locations = new String[]{firstLocation};
+    wfile.setLocations(locations);
+    String fullFilePath = "somewhere";
+
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    HttpResponseException hre = new HttpResponseException(666, "reason");
+    Mockito.when(mockConn.downloadQuery(firstLocation, fullFilePath)).thenThrow(hre);
+
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    Mockito.doReturn(fullFilePath).when(downloaderSpy).prepareOutputLocation(wfile);
+    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+
+    ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(errContent));
+
+    downloaderSpy.downloadAndValidateFile(wfile);
+    verify(mockConn, times(1)).downloadQuery(firstLocation, fullFilePath);
+    verify(downloaderSpy, never()).checksumValidate("md5", wfile, fullFilePath);
+    String expected = "ERROR: HttpResponseException (reason) downloading file (will not retry): " + firstLocation;
+    assertThat("SYSERR should indicate HttpResponseException", errContent.toString(), StringStartsWith.startsWith(expected));
+    assertThat("SYSERR should indicate Http ResponseCode", errContent.toString(), containsString("HTTP ResponseCode was 666"));
+    assertThat("SYSERR should not have stacktrace", errContent.toString(), not(containsString(".HttpResponseException")));
+  }
+
+  @Test
+  public void downloadAndValidateFile_ClientProtocolException_handled() throws IOException, SettingsLoadException, NoSuchAlgorithmException {
+    WasapiFile wfile = new WasapiFile();
+    String firstLocation = "out there";
+    String[] locations = new String[]{firstLocation};
+    wfile.setLocations(locations);
+    String fullFilePath = "somewhere";
+
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    ClientProtocolException cpe = new ClientProtocolException("reason");
+    Mockito.when(mockConn.downloadQuery(firstLocation, fullFilePath)).thenThrow(cpe);
+
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    Mockito.doReturn(fullFilePath).when(downloaderSpy).prepareOutputLocation(wfile);
+    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+
+    ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(errContent));
+
+    downloaderSpy.downloadAndValidateFile(wfile);
+    verify(mockConn, times(1)).downloadQuery(firstLocation, fullFilePath);
+    verify(downloaderSpy, never()).checksumValidate("md5", wfile, fullFilePath);
+    String expected = "ERROR: ClientProtocolException (reason) downloading file (will not retry): " + firstLocation;
+    assertThat("SYSERR should indicate ClientProtocolException", errContent.toString(), StringStartsWith.startsWith(expected));
+    assertThat("SYSERR should not have stacktrace", errContent.toString(), not(containsString(".ClientProtocolException")));
+  }
+
+  @Test
+  public void downloadAndValidateFile_IOException_handled() throws Exception{
+    WasapiFile wfile = new WasapiFile();
+    String firstLocation = "out there";
+    String[] locations = new String[]{firstLocation};
+    wfile.setLocations(locations);
+    String fullFilePath = "somewhere";
+
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    IOException ioe = new IOException("reason");
+    Mockito.when(mockConn.downloadQuery(firstLocation, fullFilePath)).thenThrow(ioe).thenReturn(false, false, false);
+
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    Mockito.doReturn(fullFilePath).when(downloaderSpy).prepareOutputLocation(wfile);
+    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+
+    ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(errContent));
+
+    downloaderSpy.downloadAndValidateFile(wfile);
+    verify(mockConn, times(WasapiDownloader.NUM_RETRIES + 1)).downloadQuery(firstLocation, fullFilePath);
+    verify(downloaderSpy, never()).checksumValidate("md5", wfile, fullFilePath);
+    String expected = "WARNING: exception downloading file (will retry): " + firstLocation;
+    assertThat("SYSERR should indicate IOException", errContent.toString(), StringStartsWith.startsWith(expected));
+    assertThat("SYSERR should have stacktrace", errContent.toString(), containsString("java.io.IOException: reason"));
+  }
+}

--- a/test/edu/stanford/dlss/was/TestWasapiDownloader_PowerMock.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloader_PowerMock.java
@@ -1,0 +1,199 @@
+package edu.stanford.dlss.was;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.*;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({WasapiDownloader.class, WasapiValidator.class})
+@SuppressWarnings("TypeName")
+/**
+ * Tests for WasapiDownloader that require PowerMock
+ *   split out because jacoco at this time (2017-05-31) is unable to record coverage for PowerMock tests ...
+ *   thus, this splitting lets us get coverage stats for WasapiDownloader for those tests that don't need PowerMock
+ */
+public class TestWasapiDownloader_PowerMock {
+
+  @Test
+  public void main_callsExecutFromCmdLine() throws Exception {
+    WasapiDownloader mockDownloader = PowerMockito.mock(WasapiDownloader.class);
+    PowerMockito.whenNew(WasapiDownloader.class).withAnyArguments().thenReturn(mockDownloader);
+
+    WasapiDownloader.main(null);
+    verify(mockDownloader).executeFromCmdLine();
+  }
+
+  @Test
+  public void main_executesFileSetRequest_usesAllAppropArgsSettings() throws Exception {
+    String[] args = {"--collectionId", "123", "--jobId=456", "--crawlStartAfter", "2014-03-14", "--crawlStartBefore=2017-03-14", "--username=Fred" };
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(null);
+    WasapiDownloader downloaderSpy = PowerMockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, args));
+    PowerMockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+    PowerMockito.whenNew(WasapiDownloader.class).withAnyArguments().thenReturn(downloaderSpy);
+
+    WasapiDownloader.main(args);
+    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("collection=123"));
+    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("crawl=456"));
+    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-after=2014-03-14"));
+    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-before=2017-03-14"));
+    // username is used in login request
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("username=Fred"));
+    // output directory is not part of wasapi request
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains(WasapiDownloaderSettings.OUTPUT_BASE_DIR_PARAM_NAME));
+  }
+
+  @Test
+  public void main_executesFileSetRequest_onlyUsesArgsSettings() throws Exception {
+    String[] args = {"--collectionId", "123" };
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(null);
+    WasapiDownloader downloaderSpy = PowerMockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, args));
+    PowerMockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+    PowerMockito.whenNew(WasapiDownloader.class).withAnyArguments().thenReturn(downloaderSpy);
+
+    WasapiDownloader.main(args);
+    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("collection=123"));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl="));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-after="));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-before="));
+  }
+
+  @Test
+  public void main_singleFileDownload_onlyUsesFilename() throws Exception {
+    String[] args = {"--collectionId", "123", "--filename", "ARCHIVEIT-5425-MONTHLY-JOB302671-20170526114117181-00049.warc.gz" };
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(null);
+    WasapiDownloader downloaderSpy = PowerMockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, args));
+    PowerMockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+    PowerMockito.whenNew(WasapiDownloader.class).withAnyArguments().thenReturn(downloaderSpy);
+
+    WasapiDownloader.main(args);
+    verify(mockConn).pagedJsonQuery(ArgumentMatchers.contains("filename=ARCHIVEIT-5425-MONTHLY-JOB302671-20170526114117181-00049.warc.gz"));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl="));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-after="));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("crawl-start-before="));
+    verify(mockConn, Mockito.never()).pagedJsonQuery(ArgumentMatchers.contains("collection="));
+  }
+
+  private List<WasapiResponse> getWasapiRespList() {
+    List<WasapiResponse> wasapiRespList = new ArrayList<WasapiResponse>();
+    wasapiRespList.add(new WasapiResponse());
+    return wasapiRespList;
+  }
+
+  @Test
+  public void downloadSelectedWarcs_usesCrawlSelector() throws Exception {
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    List<WasapiResponse> wasapiRespList = getWasapiRespList();
+    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(wasapiRespList);
+
+    WasapiCrawlSelector mockCrawlSelector = PowerMockito.mock(WasapiCrawlSelector.class);
+    List<Integer> desiredCrawlIds = new ArrayList<Integer>();
+    desiredCrawlIds.add(Integer.valueOf("666"));
+    PowerMockito.when(mockCrawlSelector.getSelectedCrawlIds(0)).thenReturn(desiredCrawlIds);
+    PowerMockito.whenNew(WasapiCrawlSelector.class).withArguments(wasapiRespList).thenReturn(mockCrawlSelector);
+
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+
+    downloaderSpy.downloadSelectedWarcs();
+    verify(mockCrawlSelector).getSelectedCrawlIds(0); // no command line args means it gets all crawl ids like this
+    verify(mockCrawlSelector).getFilesForCrawl(anyInt());
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:MethodLength")
+  public void downloadSelectedWarcs_callsDownloadAndValidateFile() throws Exception {
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    List<WasapiResponse> wasapiRespList = getWasapiRespList();
+    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(wasapiRespList);
+
+    WasapiCrawlSelector mockCrawlSelector = PowerMockito.mock(WasapiCrawlSelector.class);
+    List<Integer> desiredCrawlIds = new ArrayList<Integer>();
+    desiredCrawlIds.add(Integer.valueOf("666"));
+    PowerMockito.when(mockCrawlSelector.getSelectedCrawlIds(0)).thenReturn(desiredCrawlIds);
+    List<WasapiFile> filesForCrawl = new ArrayList<WasapiFile>();
+    WasapiFile wfile = new WasapiFile();
+    String filename = "i_is_a_warc_file";
+    wfile.setFilename(filename);
+    filesForCrawl.add(wfile);
+    PowerMockito.when(mockCrawlSelector.getFilesForCrawl(666)).thenReturn(filesForCrawl);
+    PowerMockito.whenNew(WasapiCrawlSelector.class).withAnyArguments().thenReturn(mockCrawlSelector);
+
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null));
+    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+    Mockito.doNothing().when(downloaderSpy).downloadAndValidateFile(wfile);
+
+    downloaderSpy.downloadSelectedWarcs();
+    verify(downloaderSpy).downloadAndValidateFile(wfile);
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:NoWhitespaceAfter")
+  public void downloadSelectedWarcs_byJobIdLowerBound() throws Exception {
+    String argValue = "666";
+    String[] args = { "--jobIdLowerBound=" + argValue };
+
+    WasapiCrawlSelector mockCrawlSelector = PowerMockito.mock(WasapiCrawlSelector.class);
+    List<WasapiResponse> wasapiRespList = getWasapiRespList();
+    PowerMockito.whenNew(WasapiCrawlSelector.class).withArguments(wasapiRespList).thenReturn(mockCrawlSelector);
+
+    WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
+    Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(wasapiRespList);
+    WasapiDownloader downloaderSpy = Mockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, args));
+    Mockito.doReturn(mockConn).when(downloaderSpy).getWasapiConn();
+
+    downloaderSpy.downloadSelectedWarcs();
+    verify(mockCrawlSelector).getSelectedCrawlIds(Integer.valueOf(argValue));
+  }
+
+  @Test
+  public void checksumValidate_md5_calls_wasapiValidator_validateMd5() throws SettingsLoadException, NoSuchAlgorithmException, IOException {
+    WasapiFile wfile = new WasapiFile();
+    String expectedChecksum = "666";
+    HashMap<String, String> checksumsMap = new HashMap<String, String>();
+    checksumsMap.put("md5", expectedChecksum);
+    wfile.setChecksums(checksumsMap);
+
+    PowerMockito.mockStatic(WasapiValidator.class);
+    Mockito.when(WasapiValidator.validateMd5(expectedChecksum, anyString())).thenReturn(anyBoolean());
+
+    WasapiDownloader wd = new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null);
+    wd.checksumValidate("md5", wfile, anyString());
+
+    PowerMockito.verifyStatic();
+    WasapiValidator.validateMd5(expectedChecksum, "");
+  }
+
+  @Test
+  public void checksumValidate_sha1_calls_wasapiValidator_validateSha1() throws SettingsLoadException, NoSuchAlgorithmException, IOException {
+    WasapiFile wfile = new WasapiFile();
+    String expectedChecksum = "666";
+    HashMap<String, String> checksumsMap = new HashMap<String, String>();
+    checksumsMap.put("sha1", expectedChecksum);
+    wfile.setChecksums(checksumsMap);
+
+    PowerMockito.mockStatic(WasapiValidator.class);
+    Mockito.when(WasapiValidator.validateSha1(expectedChecksum, anyString())).thenReturn(anyBoolean());
+
+    WasapiDownloader wd = new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, null);
+    wd.checksumValidate("sha1", wfile, anyString());
+
+    PowerMockito.verifyStatic();
+    WasapiValidator.validateSha1(expectedChecksum, "");
+  }
+}


### PR DESCRIPTION
this is a shameless green implementation of both the code and the tests.

Please review and indicate if it's a "must fix for merge" comment or a "make a new issue to address this" comment, or just an "FYI" comment.

Resolves #31 
Resolves #74 
Resolves #64 
Resolves #77 
Resolves #75 

Also splits out WasapiDownloader tests requiring PowerMock from other tests so our jacoco reported test coverage is closer to reality.