### PR TITLE
Settings updates

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -25,7 +25,7 @@
         <module name="AnonInnerLength"/> <!-- default 20 lines -->
         <module name="ExecutableStatementCount"/> <!-- default 30 for methods, constructors, inits -->
         <module name="LineLength">
-            <property name="max" value="150"/>
+            <property name="max" value="120"/>
         </module>
         <module name="MethodLength"> <!-- for methods, constructors -->
             <property name="max" value="20"/>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -4,6 +4,7 @@
 <suppressions>
   <suppress checks="AvoidStarImport" files="Test.+.java"/>
   <suppress checks="ClassDataAbstractionCoupling" files="Test.+.java"/>
+  <suppress checks="LineLength" files="Test.+.java"/>
   <suppress checks="MagicNumberCheck" files="Test.+.java"/>
   <suppress checks="MultipleStringLiterals" files="Test.+.java"/>
   <suppress id="MethodNameRegular" files="Test.+.java"  />

--- a/config/settings.properties
+++ b/config/settings.properties
@@ -18,3 +18,6 @@ outputBaseDir=test/outputBaseDir/
 
 # Checksum algorithm - allowed values are md5 and sha1
 checksumAlgorithm=md5
+
+# how many times to retry a download for each file (retries + 1 = total tries)
+retries=3

--- a/src/edu/stanford/dlss/was/DownloadResponseHandler.java
+++ b/src/edu/stanford/dlss/was/DownloadResponseHandler.java
@@ -17,7 +17,8 @@ public class DownloadResponseHandler implements ResponseHandler<Boolean> {
   }
 
   @Override
-  public Boolean handleResponse(final HttpResponse response) throws ClientProtocolException, HttpResponseException, IOException {
+  public Boolean handleResponse(final HttpResponse response)
+      throws ClientProtocolException, HttpResponseException, IOException {
     HttpEntity entity = response.getEntity();
 
     if (WasapiValidator.validateResponse(response.getStatusLine(), entity == null)) {

--- a/src/edu/stanford/dlss/was/JsonResponseHandler.java
+++ b/src/edu/stanford/dlss/was/JsonResponseHandler.java
@@ -11,7 +11,8 @@ import org.apache.http.client.ResponseHandler;
 public class JsonResponseHandler implements ResponseHandler<WasapiResponse> {
 
   @Override
-  public WasapiResponse handleResponse(final HttpResponse response) throws ClientProtocolException, HttpResponseException, IOException {
+  public WasapiResponse handleResponse(final HttpResponse response)
+      throws ClientProtocolException, HttpResponseException, IOException {
     HttpEntity entity = response.getEntity();
     if (WasapiValidator.validateResponse(response.getStatusLine(), entity == null))
       return new WasapiResponseParser().parse(entity.getContent());

--- a/src/edu/stanford/dlss/was/SettingsLoadException.java
+++ b/src/edu/stanford/dlss/was/SettingsLoadException.java
@@ -1,9 +1,9 @@
 package edu.stanford.dlss.was;
 
 /**
- * Wrapper exception used when loading app settings.
+ * Wrapper exception used when loading app settings from properties file and command line arguments.
  *
- * Keeps callers from having to know all the underlying exceptions that might get thrown when reading properties and parsing CLI args.
+ * Shields callers knowing which underlying exceptions could be thrown.
  */
 class SettingsLoadException extends Exception {
   SettingsLoadException(String message) {

--- a/src/edu/stanford/dlss/was/WasapiConnection.java
+++ b/src/edu/stanford/dlss/was/WasapiConnection.java
@@ -40,7 +40,8 @@ public class WasapiConnection {
     return wasapiRespList;
   }
 
-  public Boolean downloadQuery(String downloadURL, final String outputPath) throws ClientProtocolException, HttpResponseException, IOException {
+  public Boolean downloadQuery(String downloadURL, final String outputPath)
+      throws ClientProtocolException, HttpResponseException, IOException {
     HttpGet fileRequest = new HttpGet(downloadURL);
     return wasapiClient.execute(fileRequest, new DownloadResponseHandler(outputPath));
   }

--- a/src/edu/stanford/dlss/was/WasapiDownloader.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloader.java
@@ -79,11 +79,13 @@ public class WasapiDownloader {
           checksumValidated = true; // break out of loop
         }
       } catch (HttpResponseException e) {
-        System.err.println("ERROR: HttpResponseException (" + e.getMessage() + ") downloading file (will not retry): " + file.getLocations()[0]);
+        String prefix = "ERROR: HttpResponseException (" + e.getMessage() + ") downloading file (will not retry): ";
+        System.err.println(prefix + file.getLocations()[0]);
         System.err.println(" HTTP ResponseCode was " + e.getStatusCode());
         attempts = NUM_RETRIES + 1;  // no more attempts
       } catch (ClientProtocolException e) {
-        System.err.println("ERROR: ClientProtocolException (" + e.getMessage() + ") downloading file (will not retry): " + file.getLocations()[0]);
+        String prefix = "ERROR: ClientProtocolException (" + e.getMessage() + ") downloading file (will not retry): ";
+        System.err.println(prefix + file.getLocations()[0]);
         attempts = NUM_RETRIES + 1;  // no more attempts
       } catch (IOException e) {
         // swallow exception and try again - it may be a network issue
@@ -98,13 +100,15 @@ public class WasapiDownloader {
 
   // package level method for testing
   String prepareOutputLocation(WasapiFile file) {
-    String outputPath = settings.outputBaseDir() + "AIT_" + file.getCollectionId() + SEP + file.getCrawlId() + SEP + file.getCrawlStartDateStr();
+    String outputPath = settings.outputBaseDir() + "AIT_" + file.getCollectionId() +
+        SEP + file.getCrawlId() + SEP + file.getCrawlStartDateStr();
     new File(outputPath).mkdirs();
     return outputPath + SEP + file.getFilename();
   }
 
   // package level method for testing
-  boolean checksumValidate(String algorithm, WasapiFile file, String fullFilePath) throws NoSuchAlgorithmException, IOException {
+  boolean checksumValidate(String algorithm, WasapiFile file, String fullFilePath)
+      throws NoSuchAlgorithmException, IOException {
     String checksum = file.getChecksums().get(algorithm);
     if (checksum == null) {
       System.err.println("No checksum of type: " + algorithm + " available: " + file.getChecksums().toString());

--- a/src/edu/stanford/dlss/was/WasapiDownloader.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloader.java
@@ -15,9 +15,6 @@ public class WasapiDownloader {
   public static final String SETTINGS_FILE_LOCATION = "config/settings.properties";
   private static final char SEP = File.separatorChar;
 
-  // TODO:  use setting (see wasapi-downloader#93 in github)
-  public static final int NUM_RETRIES = 3;
-
   public WasapiDownloaderSettings settings;
 
   private WasapiConnection wasapiConn;
@@ -68,6 +65,7 @@ public class WasapiDownloader {
       System.err.println("fullFilePath is null - can't retrieve file");
       return;
     }
+    int numRetries = Integer.parseInt(settings.retries());
     int attempts = 0;
     boolean checksumValidated = false;
     do {
@@ -82,19 +80,19 @@ public class WasapiDownloader {
         String prefix = "ERROR: HttpResponseException (" + e.getMessage() + ") downloading file (will not retry): ";
         System.err.println(prefix + file.getLocations()[0]);
         System.err.println(" HTTP ResponseCode was " + e.getStatusCode());
-        attempts = NUM_RETRIES + 1;  // no more attempts
+        attempts = numRetries + 1;  // no more attempts
       } catch (ClientProtocolException e) {
         String prefix = "ERROR: ClientProtocolException (" + e.getMessage() + ") downloading file (will not retry): ";
         System.err.println(prefix + file.getLocations()[0]);
-        attempts = NUM_RETRIES + 1;  // no more attempts
+        attempts = numRetries + 1;  // no more attempts
       } catch (IOException e) {
         // swallow exception and try again - it may be a network issue
         System.err.println("WARNING: exception downloading file (will retry): " + file.getLocations()[0]);
         e.printStackTrace(System.err);
       }
-    } while (attempts <= NUM_RETRIES && !checksumValidated);
+    } while (attempts <= numRetries && !checksumValidated);
 
-    if (attempts == NUM_RETRIES + 1) // RE-tries, not number of attempts
+    if (attempts == numRetries + 1) // RE-tries, not number of attempts
       System.err.println("file not retrieved or unable to validate checksum: " + file.getLocations()[0]);
   }
 

--- a/src/edu/stanford/dlss/was/WasapiDownloader.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloader.java
@@ -123,10 +123,10 @@ public class WasapiDownloader {
 
   private List<Integer> desiredCrawlIds(WasapiCrawlSelector crawlSelector) {
     // TODO: want cleaner grab of int from settings: wasapi-downloader#83
-    Integer myInteger = IntegerValidator.getInstance().validate(settings.jobIdLowerBound());
+    Integer myInteger = IntegerValidator.getInstance().validate(settings.crawlIdLowerBound());
     if (myInteger != null) {
-      int jobsAfter = myInteger.intValue();
-      return crawlSelector.getSelectedCrawlIds(jobsAfter);
+      int crawlsAfter = myInteger.intValue();
+      return crawlSelector.getSelectedCrawlIds(crawlsAfter);
     }
     else
       return crawlSelector.getSelectedCrawlIds(0); // all returns all crawl ids from FileSet
@@ -159,8 +159,8 @@ public class WasapiDownloader {
       params.add("crawl-start-after=" + settings.crawlStartAfter());
     if (settings.crawlStartBefore()!= null)
       params.add("crawl-start-before=" + settings.crawlStartBefore());
-    if (settings.jobId() != null)
-      params.add("crawl=" + settings.jobId());
+    if (settings.crawlId() != null)
+      params.add("crawl=" + settings.crawlId());
     return params;
   }
 

--- a/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
@@ -32,20 +32,20 @@ public class WasapiDownloaderSettings {
   // * add an accessor method (preferably with a name corresponding to the setting name)
   // * add the appropriate validation in getSettingsErrorMessages()
   // * add tests to make sure it: shows up in usage info and settings dump; is checked for validity; has a value in example settings, if applicable
-  public static final String BASE_URL_PARAM_NAME = "baseurl";
-  public static final String AUTH_URL_PARAM_NAME = "authurl";
-  public static final String USERNAME_PARAM_NAME = "username";
-  public static final String PASSWORD_PARAM_NAME = "password";
-  public static final String ACCCOUNT_ID_PARAM_NAME = "accountId";
   public static final String HELP_PARAM_NAME = "help";
+  public static final String ACCCOUNT_ID_PARAM_NAME = "accountId";
+  public static final String AUTH_URL_PARAM_NAME = "authurl";
+  public static final String BASE_URL_PARAM_NAME = "baseurl";
+  public static final String CHECKSUM_ALGORITHM_PARAM_NAME = "checksumAlgorithm";
   public static final String COLLECTION_ID_PARAM_NAME = "collectionId";
   public static final String CRAWL_ID_PARAM_NAME = "crawlId";
+  public static final String CRAWL_ID_LOWER_BOUND_PARAM_NAME = "crawlIdLowerBound";
   public static final String CRAWL_START_AFTER_PARAM_NAME = "crawlStartAfter";
   public static final String CRAWL_START_BEFORE_PARAM_NAME = "crawlStartBefore";
-  public static final String CRAWL_ID_LOWER_BOUND_PARAM_NAME = "crawlIdLowerBound";
-  public static final String OUTPUT_BASE_DIR_PARAM_NAME = "outputBaseDir";
   public static final String FILENAME_PARAM_NAME = "filename";
-  public static final String CHECKSUM_ALGORITHM_PARAM_NAME = "checksumAlgorithm";
+  public static final String OUTPUT_BASE_DIR_PARAM_NAME = "outputBaseDir";
+  public static final String PASSWORD_PARAM_NAME = "password";
+  public static final String USERNAME_PARAM_NAME = "username";
 
   protected PrintStream errStream = System.err;
   protected Properties settings;
@@ -55,20 +55,20 @@ public class WasapiDownloaderSettings {
   private String helpAndSettingsMessage;
 
   private static Option[] optList = {
-    Option.builder("h").longOpt(HELP_PARAM_NAME).desc("print this message (which describes expected arguments and dumps current config)").build(),
-    buildArgOption(BASE_URL_PARAM_NAME, "the base URL of the WASAPI server from which to pull WARC files"),
-    buildArgOption(AUTH_URL_PARAM_NAME, "the WASAPI server URL at which login credentials are passed"),
-    buildArgOption(USERNAME_PARAM_NAME, "the username for WASAPI server login"),
-    buildArgOption(PASSWORD_PARAM_NAME, "the password for WASAPI server login"),
-    buildArgOption(ACCCOUNT_ID_PARAM_NAME, "the ID for the account from which WARC files are downloaded"),
-    buildArgOption(COLLECTION_ID_PARAM_NAME, "a collection from which to download crawl files"),
-    buildArgOption(CRAWL_ID_PARAM_NAME, "crawl id from which to download files"),
-    buildArgOption(CRAWL_START_AFTER_PARAM_NAME, "only download crawl files created after this date"),
-    buildArgOption(CRAWL_START_BEFORE_PARAM_NAME, "only download crawl files created before this date"),
-    buildArgOption(CRAWL_ID_LOWER_BOUND_PARAM_NAME, "\"last crawl downloaded\": only download crawl files with a higher crawl ID (not inclusive)"),
-    buildArgOption(OUTPUT_BASE_DIR_PARAM_NAME, "destination directory for downloaded WARC files"),
-    buildArgOption(FILENAME_PARAM_NAME, "single filename to download"),
-    buildArgOption(CHECKSUM_ALGORITHM_PARAM_NAME, "checksum algorithm to use (either md5 or sha1")
+    Option.builder("h").longOpt(HELP_PARAM_NAME).desc("print this message describing arguments and current configuration)").build(),
+    buildArgOption(ACCCOUNT_ID_PARAM_NAME, "limit files to this account (e.g. when multiple accounts per username)"),
+    buildArgOption(AUTH_URL_PARAM_NAME, "WASAPI server URL for login credentials"),
+    buildArgOption(BASE_URL_PARAM_NAME, "base URL of WASAPI server (expects ending slash)"),
+    buildArgOption(CHECKSUM_ALGORITHM_PARAM_NAME, "checksum algorithm to use (md5 or sha1"),
+    buildArgOption(COLLECTION_ID_PARAM_NAME, "limit files to this collection"),
+    buildArgOption(CRAWL_ID_PARAM_NAME, "limit files to this crawl id"),
+    buildArgOption(CRAWL_ID_LOWER_BOUND_PARAM_NAME, "\"last crawl downloaded\": limit files to crawls with a higher crawl ID (not inclusive)"),
+    buildArgOption(CRAWL_START_AFTER_PARAM_NAME, "limit files to crawls started after this date"),
+    buildArgOption(CRAWL_START_BEFORE_PARAM_NAME, "limit files to crawls started before this date"),
+    buildArgOption(FILENAME_PARAM_NAME, "name of single file to download"),
+    buildArgOption(OUTPUT_BASE_DIR_PARAM_NAME, "destination directory for downloaded files (expects ending slash)"),
+    buildArgOption(PASSWORD_PARAM_NAME, "password for WASAPI server login"),
+    buildArgOption(USERNAME_PARAM_NAME, "username for WASAPI server login")
   };
 
   static {
@@ -101,24 +101,20 @@ public class WasapiDownloaderSettings {
     return settings.getProperty(HELP_PARAM_NAME) != null;
   }
 
-  public String baseUrlString() {
-    return settings.getProperty(BASE_URL_PARAM_NAME);
+  public String accountId() {
+    return settings.getProperty(ACCCOUNT_ID_PARAM_NAME);
   }
 
   public String authUrlString() {
     return settings.getProperty(AUTH_URL_PARAM_NAME);
   }
 
-  public String username() {
-    return settings.getProperty(USERNAME_PARAM_NAME);
+  public String baseUrlString() {
+    return settings.getProperty(BASE_URL_PARAM_NAME);
   }
 
-  public String password() {
-    return settings.getProperty(PASSWORD_PARAM_NAME);
-  }
-
-  public String accountId() {
-    return settings.getProperty(ACCCOUNT_ID_PARAM_NAME);
+  public String checksumAlgorithm() {
+    return settings.getProperty(CHECKSUM_ALGORITHM_PARAM_NAME);
   }
 
   public String collectionId() {
@@ -127,6 +123,10 @@ public class WasapiDownloaderSettings {
 
   public String crawlId() {
     return settings.getProperty(CRAWL_ID_PARAM_NAME);
+  }
+
+  public String crawlIdLowerBound() {
+    return settings.getProperty(CRAWL_ID_LOWER_BOUND_PARAM_NAME);
   }
 
   // e.g. 2014-01-01, see https://github.com/WASAPI-Community/data-transfer-apis/tree/master/ait-reference-specification#paths--examples
@@ -139,21 +139,22 @@ public class WasapiDownloaderSettings {
     return settings.getProperty(CRAWL_START_BEFORE_PARAM_NAME);
   }
 
-  public String crawlIdLowerBound() {
-    return settings.getProperty(CRAWL_ID_LOWER_BOUND_PARAM_NAME);
+  public String filename() {
+    return settings.getProperty(FILENAME_PARAM_NAME);
   }
 
   public String outputBaseDir() {
     return settings.getProperty(OUTPUT_BASE_DIR_PARAM_NAME);
   }
 
-  public String filename() {
-    return settings.getProperty(FILENAME_PARAM_NAME);
+  public String password() {
+    return settings.getProperty(PASSWORD_PARAM_NAME);
   }
 
-  public String checksumAlgorithm() {
-    return settings.getProperty(CHECKSUM_ALGORITHM_PARAM_NAME);
+  public String username() {
+    return settings.getProperty(USERNAME_PARAM_NAME);
   }
+
 
   public String getHelpAndSettingsMessage() {
     if (helpAndSettingsMessage == null)

--- a/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
@@ -24,7 +24,7 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.validator.routines.IntegerValidator;
 import org.apache.commons.validator.routines.UrlValidator;
 
-@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity", "checkstyle:LineLength"})
 public class WasapiDownloaderSettings {
   // to add a new setting:
   // * add a String constant for the setting/arg name

--- a/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
@@ -39,10 +39,10 @@ public class WasapiDownloaderSettings {
   public static final String ACCCOUNT_ID_PARAM_NAME = "accountId";
   public static final String HELP_PARAM_NAME = "help";
   public static final String COLLECTION_ID_PARAM_NAME = "collectionId";
-  public static final String JOB_ID_PARAM_NAME = "jobId";
+  public static final String CRAWL_ID_PARAM_NAME = "crawlId";
   public static final String CRAWL_START_AFTER_PARAM_NAME = "crawlStartAfter";
   public static final String CRAWL_START_BEFORE_PARAM_NAME = "crawlStartBefore";
-  public static final String JOB_ID_LOWER_BOUND_PARAM_NAME = "jobIdLowerBound";
+  public static final String CRAWL_ID_LOWER_BOUND_PARAM_NAME = "crawlIdLowerBound";
   public static final String OUTPUT_BASE_DIR_PARAM_NAME = "outputBaseDir";
   public static final String FILENAME_PARAM_NAME = "filename";
   public static final String CHECKSUM_ALGORITHM_PARAM_NAME = "checksumAlgorithm";
@@ -62,10 +62,10 @@ public class WasapiDownloaderSettings {
     buildArgOption(PASSWORD_PARAM_NAME, "the password for WASAPI server login"),
     buildArgOption(ACCCOUNT_ID_PARAM_NAME, "the ID for the account from which WARC files are downloaded"),
     buildArgOption(COLLECTION_ID_PARAM_NAME, "a collection from which to download crawl files"),
-    buildArgOption(JOB_ID_PARAM_NAME, "a job from which to download crawl files"),
+    buildArgOption(CRAWL_ID_PARAM_NAME, "crawl id from which to download files"),
     buildArgOption(CRAWL_START_AFTER_PARAM_NAME, "only download crawl files created after this date"),
     buildArgOption(CRAWL_START_BEFORE_PARAM_NAME, "only download crawl files created before this date"),
-    buildArgOption(JOB_ID_LOWER_BOUND_PARAM_NAME, "\"last crawl downloaded\": only download crawl files with a higher job ID (not inclusive)"),
+    buildArgOption(CRAWL_ID_LOWER_BOUND_PARAM_NAME, "\"last crawl downloaded\": only download crawl files with a higher crawl ID (not inclusive)"),
     buildArgOption(OUTPUT_BASE_DIR_PARAM_NAME, "destination directory for downloaded WARC files"),
     buildArgOption(FILENAME_PARAM_NAME, "single filename to download"),
     buildArgOption(CHECKSUM_ALGORITHM_PARAM_NAME, "checksum algorithm to use (either md5 or sha1")
@@ -125,8 +125,8 @@ public class WasapiDownloaderSettings {
     return settings.getProperty(COLLECTION_ID_PARAM_NAME);
   }
 
-  public String jobId() {
-    return settings.getProperty(JOB_ID_PARAM_NAME);
+  public String crawlId() {
+    return settings.getProperty(CRAWL_ID_PARAM_NAME);
   }
 
   // e.g. 2014-01-01, see https://github.com/WASAPI-Community/data-transfer-apis/tree/master/ait-reference-specification#paths--examples
@@ -139,8 +139,8 @@ public class WasapiDownloaderSettings {
     return settings.getProperty(CRAWL_START_BEFORE_PARAM_NAME);
   }
 
-  public String jobIdLowerBound() {
-    return settings.getProperty(JOB_ID_LOWER_BOUND_PARAM_NAME);
+  public String crawlIdLowerBound() {
+    return settings.getProperty(CRAWL_ID_LOWER_BOUND_PARAM_NAME);
   }
 
   public String outputBaseDir() {
@@ -207,14 +207,14 @@ public class WasapiDownloaderSettings {
       errMessages.add(ACCCOUNT_ID_PARAM_NAME + " must be an integer (if specified)");
     if (!isNullOrEmpty(collectionId()) && !intValidator.isValid(collectionId()))
       errMessages.add(COLLECTION_ID_PARAM_NAME + " must be an integer (if specified)");
-    if (!isNullOrEmpty(jobId()) && !intValidator.isValid(jobId()))
-      errMessages.add(JOB_ID_PARAM_NAME + " must be an integer (if specified)");
+    if (!isNullOrEmpty(crawlId()) && !intValidator.isValid(crawlId()))
+      errMessages.add(CRAWL_ID_PARAM_NAME + " must be an integer (if specified)");
     if (!isNullOrEmpty(crawlStartBefore()) && !normalizeIso8601Setting(CRAWL_START_BEFORE_PARAM_NAME))
       errMessages.add(CRAWL_START_BEFORE_PARAM_NAME + " must be a valid ISO 8601 date string (if specified)");
     if (!isNullOrEmpty(crawlStartAfter()) && !normalizeIso8601Setting(CRAWL_START_AFTER_PARAM_NAME))
       errMessages.add(CRAWL_START_AFTER_PARAM_NAME + " must be a valid ISO 8601 date string (if specified)");
-    if (!isNullOrEmpty(jobIdLowerBound()) && !intValidator.isValid(jobIdLowerBound()))
-      errMessages.add(JOB_ID_LOWER_BOUND_PARAM_NAME + " must be an integer (if specified)");
+    if (!isNullOrEmpty(crawlIdLowerBound()) && !intValidator.isValid(crawlIdLowerBound()))
+      errMessages.add(CRAWL_ID_LOWER_BOUND_PARAM_NAME + " must be an integer (if specified)");
 
     return errMessages;
   }

--- a/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
+++ b/src/edu/stanford/dlss/was/WasapiDownloaderSettings.java
@@ -45,6 +45,7 @@ public class WasapiDownloaderSettings {
   public static final String FILENAME_PARAM_NAME = "filename";
   public static final String OUTPUT_BASE_DIR_PARAM_NAME = "outputBaseDir";
   public static final String PASSWORD_PARAM_NAME = "password";
+  public static final String RETRIES_PARAM_NAME = "retries";
   public static final String USERNAME_PARAM_NAME = "username";
 
   protected PrintStream errStream = System.err;
@@ -68,6 +69,7 @@ public class WasapiDownloaderSettings {
     buildArgOption(FILENAME_PARAM_NAME, "name of single file to download"),
     buildArgOption(OUTPUT_BASE_DIR_PARAM_NAME, "destination directory for downloaded files (expects ending slash)"),
     buildArgOption(PASSWORD_PARAM_NAME, "password for WASAPI server login"),
+    buildArgOption(RETRIES_PARAM_NAME, "how many times to retry a download for each file (retries + 1 = total tries)"),
     buildArgOption(USERNAME_PARAM_NAME, "username for WASAPI server login")
   };
 
@@ -151,6 +153,10 @@ public class WasapiDownloaderSettings {
     return settings.getProperty(PASSWORD_PARAM_NAME);
   }
 
+  public String retries() {
+    return settings.getProperty(RETRIES_PARAM_NAME);
+  }
+
   public String username() {
     return settings.getProperty(USERNAME_PARAM_NAME);
   }
@@ -202,6 +208,8 @@ public class WasapiDownloaderSettings {
       errMessages.add(OUTPUT_BASE_DIR_PARAM_NAME + " is required (and must be an extant, writable directory)");
     if (isNullOrEmpty(checksumAlgorithm()) || !("md5".equals(checksumAlgorithm())) || "sha1".equals(checksumAlgorithm()))
       errMessages.add(CHECKSUM_ALGORITHM_PARAM_NAME + " is required and must be md5 or sha1");
+    if (isNullOrEmpty(retries()) || !intValidator.isValid(retries()) || !intValidator.minValue(Integer.valueOf(retries()), 0))
+      errMessages.add(RETRIES_PARAM_NAME + " is required and must be an integer >= 0");
 
     // optional, validate if specified
     if (!isNullOrEmpty(accountId()) && !intValidator.isValid(accountId()))

--- a/src/edu/stanford/dlss/was/WasapiFile.java
+++ b/src/edu/stanford/dlss/was/WasapiFile.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@SuppressWarnings("checkstyle:LineLength")
 /**
  * Class corresponding to JSON returned by WASAPI that represents WebdataFile
  * @see https://github.com/WASAPI-Community/data-transfer-apis/blob/master/ait-implementation/wasapi/implemented-swagger.yaml#L132-L183

--- a/src/edu/stanford/dlss/was/WasapiResponse.java
+++ b/src/edu/stanford/dlss/was/WasapiResponse.java
@@ -2,6 +2,7 @@ package edu.stanford.dlss.was;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@SuppressWarnings("checkstyle:LineLength")
 /**
  * Class corresponding to JSON received after making WASAPI request ("FileSet")
  * @see https://github.com/WASAPI-Community/data-transfer-apis/blob/master/ait-implementation/wasapi/implemented-swagger.yaml#L184-L213

--- a/src/edu/stanford/dlss/was/WasapiValidator.java
+++ b/src/edu/stanford/dlss/was/WasapiValidator.java
@@ -17,7 +17,8 @@ import org.apache.http.client.HttpResponseException;
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
 public class WasapiValidator {
 
-  public static boolean validateResponse(StatusLine statusLine, boolean entityIsNull) throws ClientProtocolException, HttpResponseException {
+  public static boolean validateResponse(StatusLine statusLine, boolean entityIsNull)
+      throws ClientProtocolException, HttpResponseException {
     if(statusLine.getStatusCode() != HttpStatus.SC_OK) {
       throw new HttpResponseException(statusLine.getStatusCode(), statusLine.getReasonPhrase());
     }

--- a/test/edu/stanford/dlss/was/TestDownloadResponseHandler.java
+++ b/test/edu/stanford/dlss/was/TestDownloadResponseHandler.java
@@ -15,11 +15,8 @@ import org.apache.http.message.BasicStatusLine;
 import org.junit.*;
 import static org.junit.Assert.*;
 import org.mockito.*;
-import org.mockito.Mockito.*;
 import org.mockito.invocation.*;
 import org.mockito.stubbing.*;
-
-
 
 public class TestDownloadResponseHandler {
   private static final char SEP = File.separatorChar;
@@ -27,24 +24,16 @@ public class TestDownloadResponseHandler {
   private static final String OUTPUT_FILE_PATH = new String(OUTPUT_DIRECTORY + SEP + "testDownloadResponseHandler.output");
   private static final StatusLine VALID_STATUS_LINE = new BasicStatusLine(new ProtocolVersion("HTTP 1/1", 1, 1), 200, "OK");
 
-  private void writeToFile() throws IOException {
-    new File(OUTPUT_FILE_PATH).createNewFile();
-    return;
-  }
-
-
   @Before
   public void setUp() {
     new File(OUTPUT_DIRECTORY).mkdir();
   }
-
 
   @After
   public void tearDown() {
     new File(OUTPUT_FILE_PATH).delete();
     new File(OUTPUT_DIRECTORY).delete();
   }
-
 
   @Test(expected = ClientProtocolException.class)
   public void nullEntityThrowsException() throws ClientProtocolException, HttpResponseException, IOException {
@@ -56,7 +45,6 @@ public class TestDownloadResponseHandler {
     handler.handleResponse(mockResponse);
   }
 
-
   @Test
   public void validResponseDownloadsFile() throws ClientProtocolException, HttpResponseException, IOException {
     DownloadResponseHandler handler = new DownloadResponseHandler(OUTPUT_FILE_PATH);
@@ -66,6 +54,7 @@ public class TestDownloadResponseHandler {
     Mockito.when(mockResponse.getStatusLine()).thenReturn(VALID_STATUS_LINE);
 
     Mockito.doAnswer(new Answer<Void>() {
+      @Override
       public Void answer(InvocationOnMock invocation) throws IOException {
         new File(OUTPUT_FILE_PATH).createNewFile();
         return null;

--- a/test/edu/stanford/dlss/was/TestDownloadResponseHandler.java
+++ b/test/edu/stanford/dlss/was/TestDownloadResponseHandler.java
@@ -62,7 +62,7 @@ public class TestDownloadResponseHandler {
     }).when(mockEntity).writeTo(ArgumentMatchers.<FileOutputStream>any(FileOutputStream.class));
 
     boolean returnValue = handler.handleResponse(mockResponse);
-    assertEquals(returnValue, true);
-    assertEquals(new File(OUTPUT_FILE_PATH).exists(), true);
+    assertEquals("return value incorrect", true, returnValue);
+    assertEquals("output file path should exist", true, new File(OUTPUT_FILE_PATH).exists());
   }
 }

--- a/test/edu/stanford/dlss/was/TestJsonResponseHandler.java
+++ b/test/edu/stanford/dlss/was/TestJsonResponseHandler.java
@@ -42,6 +42,6 @@ public class TestJsonResponseHandler {
     Mockito.when(mockEntity.getContent()).thenReturn(new FileInputStream(new File(FIXTURE_FILE)));
 
     WasapiResponse parsedResponse = handler.handleResponse(mockResponse);
-    assertEquals(parsedResponse.getCount(), 5);
+    assertEquals("parsed response count value wrong", 5, parsedResponse.getCount());
   }
 }

--- a/test/edu/stanford/dlss/was/TestJsonResponseHandler.java
+++ b/test/edu/stanford/dlss/was/TestJsonResponseHandler.java
@@ -15,7 +15,6 @@ import org.apache.http.message.BasicStatusLine;
 import org.junit.*;
 import static org.junit.Assert.*;
 import org.mockito.*;
-import org.mockito.Mockito.*;
 
 public class TestJsonResponseHandler {
 
@@ -32,7 +31,6 @@ public class TestJsonResponseHandler {
 
     handler.handleResponse(mockResponse);
   }
-
 
   @Test
   public void validResponseParsesCorrectly() throws ClientProtocolException, HttpResponseException, IOException {

--- a/test/edu/stanford/dlss/was/TestWasapiClient.java
+++ b/test/edu/stanford/dlss/was/TestWasapiClient.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 
-import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import org.junit.*;
 import static org.mockito.Mockito.*;

--- a/test/edu/stanford/dlss/was/TestWasapiClient.java
+++ b/test/edu/stanford/dlss/was/TestWasapiClient.java
@@ -18,7 +18,7 @@ public class TestWasapiClient {
     assertNotNull(testClient.wasapiClient);
     assertNotNull(testClient.wasapiContext);
     assertNotNull(testClient.cookieStore);
-    assertEquals(testClient.settings, settings);
+    assertEquals("incorrect settings", settings, testClient.settings);
   }
 
   @Test

--- a/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
@@ -24,9 +24,9 @@ public class TestWasapiDownloaderSettings {
     // args is a String array, in the style of the `String[] args` param taken by the main method of a Java class.
     // JVM splits the whole command line argument string on whitespace, and passes the resultant String array into main, so
     // the below args array would come from something like:
-    //   wasapi-downloader -h --collectionId 123 --jobId=456 --crawlStartAfter 2014-03-14 --crawlStartBefore=2017-03-14
+    //   wasapi-downloader -h --collectionId 123 --crawlId=456 --crawlStartAfter 2014-03-14 --crawlStartBefore=2017-03-14
     // The Apache CLI parser should be able to handle all of those different styles of argument without any trouble.
-    String[] args = { "-h", "--collectionId", "123", "--jobId=456", "--crawlStartAfter", "2014-03-14", "--crawlStartBefore=2017-03-14" };
+    String[] args = { "-h", "--collectionId", "123", "--crawlId=456", "--crawlStartAfter", "2014-03-14", "--crawlStartBefore=2017-03-14" };
     WasapiDownloaderSettings settings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, args);
 
     assertEquals("baseurl value should have come from settings file", settings.baseUrlString(), "https://example.org/");
@@ -37,7 +37,7 @@ public class TestWasapiDownloaderSettings {
     assertEquals("outputBaseDir value should have come from settings file", settings.outputBaseDir(), "test/outputBaseDir/");
     assertEquals("checksumAlgorithm value should have come from settings file", settings.checksumAlgorithm(), "md5");
     assertEquals("collectionId value should have come from args", settings.collectionId(), "123");
-    assertEquals("jobId value should have come from args", settings.jobId(), "456");
+    assertEquals("crawlId value should have come from args", settings.crawlId(), "456");
     assertEquals("crawlStartAfter value should have come from args", settings.crawlStartAfter(), "2014-03-14");
     assertEquals("crawlStartBefore value should have come from args", settings.crawlStartBefore(), "2017-03-14");
     assertTrue("shouldDisplayHelp value should have come from args", settings.shouldDisplayHelp());
@@ -46,9 +46,9 @@ public class TestWasapiDownloaderSettings {
   @Test
   @SuppressWarnings({"checkstyle:NoWhitespaceAfter", "checkstyle:MethodLength"})
   public void getHelpAndSettingsMessage_containsUsageAndSettingsInfo() throws SettingsLoadException {
-    //TODO: if settings validation flags possibly nonsensical/redundant combos like jobId
-    // and jobIdLowerBound, this test might have to be broken up a bit.
-    String[] args = { "-h", "--collectionId", "123", "--jobId=456", "--jobIdLowerBound=400",
+    //TODO: if settings validation flags possibly nonsensical/redundant combos like crawlId and crawlIdLowerBound,
+    // then this test might have to be broken up a bit.
+    String[] args = { "-h", "--collectionId", "123", "--crawlId=456", "--crawlIdLowerBound=400",
         "--crawlStartAfter", "2014-03-14", "--crawlStartBefore=2017-03-14", "--filename=filename.warc.gz" };
     WasapiDownloaderSettings settings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, args);
 
@@ -64,17 +64,17 @@ public class TestWasapiDownloaderSettings {
     assertThat("helpAndSettingsMsg lists crawlStartAfter arg", helpAndSettingsMsg, containsString("--crawlStartAfter <arg>"));
     assertThat("helpAndSettingsMsg lists crawlStartBefore arg", helpAndSettingsMsg, containsString("--crawlStartBefore <arg>"));
     assertThat("helpAndSettingsMsg lists help flag", helpAndSettingsMsg, containsString("-h,--help"));
-    assertThat("helpAndSettingsMsg lists jobId arg", helpAndSettingsMsg, containsString("--jobId <arg>"));
-    assertThat("helpAndSettingsMsg lists jobIdLowerBound arg", helpAndSettingsMsg, containsString("--jobIdLowerBound <arg>"));
+    assertThat("helpAndSettingsMsg lists crawlId arg", helpAndSettingsMsg, containsString("--crawlId <arg>"));
+    assertThat("helpAndSettingsMsg lists crawlIdLowerBound arg", helpAndSettingsMsg, containsString("--crawlIdLowerBound <arg>"));
     assertThat("helpAndSettingsMsg lists filename arg", helpAndSettingsMsg, containsString("--filename <arg>"));
     assertThat("helpAndSettingsMsg lists checksumAlgorithm arg", helpAndSettingsMsg, containsString("--checksumAlgorithm <arg>"));
 
     assertThat("helpAndSettingsMsg hides password value", helpAndSettingsMsg, containsString("password : [password hidden]"));
     assertThat("helpAndSettingsMsg lists crawlStartAfter value", helpAndSettingsMsg, containsString("crawlStartAfter : 2014-03-14"));
     assertThat("helpAndSettingsMsg lists crawlStartBefore value", helpAndSettingsMsg, containsString("crawlStartBefore : 2017-03-14"));
-    assertThat("helpAndSettingsMsg lists jobIdLowerBound value", helpAndSettingsMsg, containsString("jobIdLowerBound : 400"));
+    assertThat("helpAndSettingsMsg lists crawlIdLowerBound value", helpAndSettingsMsg, containsString("crawlIdLowerBound : 400"));
     assertThat("helpAndSettingsMsg lists help flag value", helpAndSettingsMsg, containsString("help : true"));
-    assertThat("helpAndSettingsMsg lists jobId value", helpAndSettingsMsg, containsString("jobId : 456"));
+    assertThat("helpAndSettingsMsg lists crawlId value", helpAndSettingsMsg, containsString("crawlId : 456"));
     assertThat("helpAndSettingsMsg lists collectionId value", helpAndSettingsMsg, containsString("collectionId : 123"));
     assertThat("helpAndSettingsMsg lists baseurl value", helpAndSettingsMsg, containsString("baseurl : https://example.org"));
     assertThat("helpAndSettingsMsg lists authurl value", helpAndSettingsMsg, containsString("authurl : https://example.org/login"));
@@ -96,7 +96,7 @@ public class TestWasapiDownloaderSettings {
   @Test
   @SuppressWarnings("checkstyle:NoWhitespaceAfter")
   public void toString_aliasesGetHelpAndSettingsMessage() throws SettingsLoadException {
-    String[] args = { "-h", "--collectionId", "123", "--jobId=456", "--crawlStartAfter", "2014-03-14", "--crawlStartBefore=2017-03-14" };
+    String[] args = { "-h", "--collectionId", "123", "--crawlId=456", "--crawlStartAfter", "2014-03-14", "--crawlStartBefore=2017-03-14" };
     WasapiDownloaderSettings settings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, args);
 
     assertSame("toString should return the same String obj as getHelpAndSettingsMessage", settings.getHelpAndSettingsMessage(), settings.toString());
@@ -150,8 +150,8 @@ public class TestWasapiDownloaderSettings {
     internalSettings.setProperty(WasapiDownloaderSettings.ACCCOUNT_ID_PARAM_NAME, "z26");
     internalSettings.setProperty(WasapiDownloaderSettings.OUTPUT_BASE_DIR_PARAM_NAME, "does/not/exist");
     internalSettings.setProperty(WasapiDownloaderSettings.COLLECTION_ID_PARAM_NAME, "a1");
-    internalSettings.setProperty(WasapiDownloaderSettings.JOB_ID_PARAM_NAME, "b2");
-    internalSettings.setProperty(WasapiDownloaderSettings.JOB_ID_LOWER_BOUND_PARAM_NAME, "c3");
+    internalSettings.setProperty(WasapiDownloaderSettings.CRAWL_ID_PARAM_NAME, "b2");
+    internalSettings.setProperty(WasapiDownloaderSettings.CRAWL_ID_LOWER_BOUND_PARAM_NAME, "c3");
     internalSettings.setProperty(WasapiDownloaderSettings.CRAWL_START_BEFORE_PARAM_NAME, "01/01/2001");
     internalSettings.setProperty(WasapiDownloaderSettings.CRAWL_START_AFTER_PARAM_NAME, "12/31/2010");
     internalSettings.setProperty(WasapiDownloaderSettings.CHECKSUM_ALGORITHM_PARAM_NAME, "foo");
@@ -164,10 +164,10 @@ public class TestWasapiDownloaderSettings {
     assertThat("error messages has entry for invalid account ID", errMsgs, hasItem("accountId must be an integer (if specified)"));
     assertThat("error messages has entry for invalid outputBaseDir", errMsgs, hasItem("outputBaseDir is required (and must be an extant, writable directory)"));
     assertThat("error messages has entry for invalid collectionId", errMsgs, hasItem("collectionId must be an integer (if specified)"));
-    assertThat("error messages has entry for invalid jobId", errMsgs, hasItem("jobId must be an integer (if specified)"));
+    assertThat("error messages has entry for invalid crawlId", errMsgs, hasItem("crawlId must be an integer (if specified)"));
     assertThat("error messages has entry for invalid crawlStartBefore", errMsgs, hasItem("crawlStartBefore must be a valid ISO 8601 date string (if specified)"));
     assertThat("error messages has entry for invalid crawlStartAfter", errMsgs, hasItem("crawlStartAfter must be a valid ISO 8601 date string (if specified)"));
-    assertThat("error messages has entry for invalid jobIdLowerBound", errMsgs, hasItem("jobIdLowerBound must be an integer (if specified)"));
+    assertThat("error messages has entry for invalid crawlIdLowerBound", errMsgs, hasItem("crawlIdLowerBound must be an integer (if specified)"));
     assertThat("error messages has entry for invalid checksumAlgorithm", errMsgs, hasItem("checksumAlgorithm is required and must be md5 or sha1"));
   }
 

--- a/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
@@ -55,33 +55,36 @@ public class TestWasapiDownloaderSettings {
     String helpAndSettingsMsg = settings.getHelpAndSettingsMessage();
 
     assertThat("helpAndSettingsMsg has a usage example", helpAndSettingsMsg, containsString("usage: bin/wasapi-downloader"));
-    assertThat("helpAndSettingsMsg lists baseurl arg", helpAndSettingsMsg, containsString("--baseurl <arg>"));
-    assertThat("helpAndSettingsMsg lists authurl arg", helpAndSettingsMsg, containsString("--authurl <arg>"));
-    assertThat("helpAndSettingsMsg lists username arg", helpAndSettingsMsg, containsString("--username <arg>"));
-    assertThat("helpAndSettingsMsg lists password arg", helpAndSettingsMsg, containsString("--password <arg>"));
+
+    // allowable settings
     assertThat("helpAndSettingsMsg lists accountId arg", helpAndSettingsMsg, containsString("--accountId <arg>"));
+    assertThat("helpAndSettingsMsg lists authurl arg", helpAndSettingsMsg, containsString("--authurl <arg>"));
+    assertThat("helpAndSettingsMsg lists baseurl arg", helpAndSettingsMsg, containsString("--baseurl <arg>"));
+    assertThat("helpAndSettingsMsg lists checksumAlgorithm arg", helpAndSettingsMsg, containsString("--checksumAlgorithm <arg>"));
     assertThat("helpAndSettingsMsg lists collectionId arg", helpAndSettingsMsg, containsString("--collectionId <arg>"));
-    assertThat("helpAndSettingsMsg lists crawlStartAfter arg", helpAndSettingsMsg, containsString("--crawlStartAfter <arg>"));
-    assertThat("helpAndSettingsMsg lists crawlStartBefore arg", helpAndSettingsMsg, containsString("--crawlStartBefore <arg>"));
-    assertThat("helpAndSettingsMsg lists help flag", helpAndSettingsMsg, containsString("-h,--help"));
     assertThat("helpAndSettingsMsg lists crawlId arg", helpAndSettingsMsg, containsString("--crawlId <arg>"));
     assertThat("helpAndSettingsMsg lists crawlIdLowerBound arg", helpAndSettingsMsg, containsString("--crawlIdLowerBound <arg>"));
+    assertThat("helpAndSettingsMsg lists crawlStartAfter arg", helpAndSettingsMsg, containsString("--crawlStartAfter <arg>"));
+    assertThat("helpAndSettingsMsg lists crawlStartBefore arg", helpAndSettingsMsg, containsString("--crawlStartBefore <arg>"));
     assertThat("helpAndSettingsMsg lists filename arg", helpAndSettingsMsg, containsString("--filename <arg>"));
-    assertThat("helpAndSettingsMsg lists checksumAlgorithm arg", helpAndSettingsMsg, containsString("--checksumAlgorithm <arg>"));
+    assertThat("helpAndSettingsMsg lists help flag", helpAndSettingsMsg, containsString("-h,--help"));
+    assertThat("helpAndSettingsMsg lists password arg", helpAndSettingsMsg, containsString("--password <arg>"));
+    assertThat("helpAndSettingsMsg lists username arg", helpAndSettingsMsg, containsString("--username <arg>"));
 
-    assertThat("helpAndSettingsMsg hides password value", helpAndSettingsMsg, containsString("password : [password hidden]"));
+    // values
+    assertThat("helpAndSettingsMsg lists accountId value", helpAndSettingsMsg, containsString("accountId : 1"));
+    assertThat("helpAndSettingsMsg lists authurl value", helpAndSettingsMsg, containsString("authurl : https://example.org/login"));
+    assertThat("helpAndSettingsMsg lists baseurl value", helpAndSettingsMsg, containsString("baseurl : https://example.org"));
+    assertThat("helpAndSettingsMsg lists checksumAlgorithm value", helpAndSettingsMsg, containsString("checksumAlgorithm : md5"));
+    assertThat("helpAndSettingsMsg lists collectionId value", helpAndSettingsMsg, containsString("collectionId : 123"));
+    assertThat("helpAndSettingsMsg lists crawlId value", helpAndSettingsMsg, containsString("crawlId : 456"));
+    assertThat("helpAndSettingsMsg lists crawlIdLowerBound value", helpAndSettingsMsg, containsString("crawlIdLowerBound : 400"));
     assertThat("helpAndSettingsMsg lists crawlStartAfter value", helpAndSettingsMsg, containsString("crawlStartAfter : 2014-03-14"));
     assertThat("helpAndSettingsMsg lists crawlStartBefore value", helpAndSettingsMsg, containsString("crawlStartBefore : 2017-03-14"));
-    assertThat("helpAndSettingsMsg lists crawlIdLowerBound value", helpAndSettingsMsg, containsString("crawlIdLowerBound : 400"));
-    assertThat("helpAndSettingsMsg lists help flag value", helpAndSettingsMsg, containsString("help : true"));
-    assertThat("helpAndSettingsMsg lists crawlId value", helpAndSettingsMsg, containsString("crawlId : 456"));
-    assertThat("helpAndSettingsMsg lists collectionId value", helpAndSettingsMsg, containsString("collectionId : 123"));
-    assertThat("helpAndSettingsMsg lists baseurl value", helpAndSettingsMsg, containsString("baseurl : https://example.org"));
-    assertThat("helpAndSettingsMsg lists authurl value", helpAndSettingsMsg, containsString("authurl : https://example.org/login"));
-    assertThat("helpAndSettingsMsg lists username value", helpAndSettingsMsg, containsString("username : user"));
-    assertThat("helpAndSettingsMsg lists accountId value", helpAndSettingsMsg, containsString("accountId : 1"));
     assertThat("helpAndSettingsMsg lists filename value", helpAndSettingsMsg, containsString("filename : filename.warc.gz"));
-    assertThat("helpAndSettingsMsg lists checksumAlgorithm value", helpAndSettingsMsg, containsString("checksumAlgorithm : md5"));
+    assertThat("helpAndSettingsMsg lists help flag value", helpAndSettingsMsg, containsString("help : true"));
+    assertThat("helpAndSettingsMsg hides password value", helpAndSettingsMsg, containsString("password : [password hidden]"));
+    assertThat("helpAndSettingsMsg lists username value", helpAndSettingsMsg, containsString("username : user"));
   }
 
   @Test
@@ -143,32 +146,32 @@ public class TestWasapiDownloaderSettings {
 
     Properties internalSettings = new Properties();
     wdSettings.settings = internalSettings;
-    internalSettings.setProperty(WasapiDownloaderSettings.BASE_URL_PARAM_NAME, "ftp://foo.org");
-    internalSettings.setProperty(WasapiDownloaderSettings.AUTH_URL_PARAM_NAME, "http://foo.com/auth");
-    internalSettings.setProperty(WasapiDownloaderSettings.USERNAME_PARAM_NAME, "");
-    internalSettings.setProperty(WasapiDownloaderSettings.PASSWORD_PARAM_NAME, "");
     internalSettings.setProperty(WasapiDownloaderSettings.ACCCOUNT_ID_PARAM_NAME, "z26");
-    internalSettings.setProperty(WasapiDownloaderSettings.OUTPUT_BASE_DIR_PARAM_NAME, "does/not/exist");
+    internalSettings.setProperty(WasapiDownloaderSettings.AUTH_URL_PARAM_NAME, "http://foo.com/auth");
+    internalSettings.setProperty(WasapiDownloaderSettings.BASE_URL_PARAM_NAME, "ftp://foo.org");
+    internalSettings.setProperty(WasapiDownloaderSettings.CHECKSUM_ALGORITHM_PARAM_NAME, "foo");
     internalSettings.setProperty(WasapiDownloaderSettings.COLLECTION_ID_PARAM_NAME, "a1");
     internalSettings.setProperty(WasapiDownloaderSettings.CRAWL_ID_PARAM_NAME, "b2");
     internalSettings.setProperty(WasapiDownloaderSettings.CRAWL_ID_LOWER_BOUND_PARAM_NAME, "c3");
-    internalSettings.setProperty(WasapiDownloaderSettings.CRAWL_START_BEFORE_PARAM_NAME, "01/01/2001");
     internalSettings.setProperty(WasapiDownloaderSettings.CRAWL_START_AFTER_PARAM_NAME, "12/31/2010");
-    internalSettings.setProperty(WasapiDownloaderSettings.CHECKSUM_ALGORITHM_PARAM_NAME, "foo");
+    internalSettings.setProperty(WasapiDownloaderSettings.CRAWL_START_BEFORE_PARAM_NAME, "01/01/2001");
+    internalSettings.setProperty(WasapiDownloaderSettings.OUTPUT_BASE_DIR_PARAM_NAME, "does/not/exist");
+    internalSettings.setProperty(WasapiDownloaderSettings.PASSWORD_PARAM_NAME, "");
+    internalSettings.setProperty(WasapiDownloaderSettings.USERNAME_PARAM_NAME, "");
 
     List<String> errMsgs = wdSettings.getSettingsErrorMessages();
-    assertThat("error messages has entry for invalid base URL", errMsgs, hasItem("baseurl is required, and must be a valid URL"));
-    assertThat("error messages has entry for invalid auth URL", errMsgs, hasItem("authurl is required, and must be a valid URL"));
-    assertThat("error messages has entry for invalid username", errMsgs, hasItem("username is required"));
-    assertThat("error messages has entry for invalid password", errMsgs, hasItem("password is required"));
     assertThat("error messages has entry for invalid account ID", errMsgs, hasItem("accountId must be an integer (if specified)"));
-    assertThat("error messages has entry for invalid outputBaseDir", errMsgs, hasItem("outputBaseDir is required (and must be an extant, writable directory)"));
+    assertThat("error messages has entry for invalid auth URL", errMsgs, hasItem("authurl is required, and must be a valid URL"));
+    assertThat("error messages has entry for invalid base URL", errMsgs, hasItem("baseurl is required, and must be a valid URL"));
+    assertThat("error messages has entry for invalid checksumAlgorithm", errMsgs, hasItem("checksumAlgorithm is required and must be md5 or sha1"));
     assertThat("error messages has entry for invalid collectionId", errMsgs, hasItem("collectionId must be an integer (if specified)"));
     assertThat("error messages has entry for invalid crawlId", errMsgs, hasItem("crawlId must be an integer (if specified)"));
-    assertThat("error messages has entry for invalid crawlStartBefore", errMsgs, hasItem("crawlStartBefore must be a valid ISO 8601 date string (if specified)"));
-    assertThat("error messages has entry for invalid crawlStartAfter", errMsgs, hasItem("crawlStartAfter must be a valid ISO 8601 date string (if specified)"));
     assertThat("error messages has entry for invalid crawlIdLowerBound", errMsgs, hasItem("crawlIdLowerBound must be an integer (if specified)"));
-    assertThat("error messages has entry for invalid checksumAlgorithm", errMsgs, hasItem("checksumAlgorithm is required and must be md5 or sha1"));
+    assertThat("error messages has entry for invalid crawlStartAfter", errMsgs, hasItem("crawlStartAfter must be a valid ISO 8601 date string (if specified)"));
+    assertThat("error messages has entry for invalid crawlStartBefore", errMsgs, hasItem("crawlStartBefore must be a valid ISO 8601 date string (if specified)"));
+    assertThat("error messages has entry for invalid outputBaseDir", errMsgs, hasItem("outputBaseDir is required (and must be an extant, writable directory)"));
+    assertThat("error messages has entry for invalid password", errMsgs, hasItem("password is required"));
+    assertThat("error messages has entry for invalid username", errMsgs, hasItem("username is required"));
   }
 
   @Test

--- a/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
@@ -29,19 +29,19 @@ public class TestWasapiDownloaderSettings {
     String[] args = { "-h", "--collectionId", "123", "--crawlId=456", "--crawlStartAfter", "2014-03-14", "--crawlStartBefore=2017-03-14" };
     WasapiDownloaderSettings settings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, args);
 
-    assertEquals("baseurl value should have come from settings file", settings.baseUrlString(), "https://example.org/");
-    assertEquals("authurl value should have come from settings file", settings.authUrlString(), "https://example.org/login");
-    assertEquals("username value should have come from settings file", settings.username(), "user");
-    assertEquals("password value should have come from settings file", settings.password(), "pass");
-    assertEquals("accountId value should have come from settings file", settings.accountId(), "1");
-    assertEquals("outputBaseDir value should have come from settings file", settings.outputBaseDir(), "test/outputBaseDir/");
-    assertEquals("checksumAlgorithm value should have come from settings file", settings.checksumAlgorithm(), "md5");
-    assertEquals("retries value should have come from settings file", settings.retries(), "3");
+    assertEquals("baseurl value should have come from settings file", "https://example.org/", settings.baseUrlString());
+    assertEquals("authurl value should have come from settings file", "https://example.org/login", settings.authUrlString());
+    assertEquals("username value should have come from settings file", "user", settings.username());
+    assertEquals("password value should have come from settings file", "pass", settings.password());
+    assertEquals("accountId value should have come from settings file", "1", settings.accountId());
+    assertEquals("outputBaseDir value should have come from settings file", "test/outputBaseDir/", settings.outputBaseDir());
+    assertEquals("checksumAlgorithm value should have come from settings file", "md5", settings.checksumAlgorithm());
+    assertEquals("retries value should have come from settings file", "3", settings.retries());
 
-    assertEquals("collectionId value should have come from args", settings.collectionId(), "123");
-    assertEquals("crawlId value should have come from args", settings.crawlId(), "456");
-    assertEquals("crawlStartAfter value should have come from args", settings.crawlStartAfter(), "2014-03-14");
-    assertEquals("crawlStartBefore value should have come from args", settings.crawlStartBefore(), "2017-03-14");
+    assertEquals("collectionId value should have come from args", "123", settings.collectionId());
+    assertEquals("crawlId value should have come from args", "456", settings.crawlId());
+    assertEquals("crawlStartAfter value should have come from args", "2014-03-14", settings.crawlStartAfter());
+    assertEquals("crawlStartBefore value should have come from args", "2017-03-14", settings.crawlStartBefore());
     assertTrue("shouldDisplayHelp value should have come from args", settings.shouldDisplayHelp());
   }
 
@@ -96,8 +96,8 @@ public class TestWasapiDownloaderSettings {
   public void argsOverrideSettings() throws SettingsLoadException {
     String[] args = { "--username=user2", "--outputBaseDir=test/outputBaseDir2" };
     WasapiDownloaderSettings settings = new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, args);
-    assertEquals("the username from the .properties file should get overridden by the command-line arg", settings.username(), "user2");
-    assertEquals("the outputBaseDir from the .properties file should get overridden by the command-line arg", settings.outputBaseDir(), "test/outputBaseDir2");
+    assertEquals("the username from the .properties file should get overridden by the command-line arg", "user2", settings.username());
+    assertEquals("the outputBaseDir from the .properties file should get overridden by the command-line arg", "test/outputBaseDir2", settings.outputBaseDir());
   }
 
   @Test

--- a/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloaderSettings.java
@@ -36,6 +36,8 @@ public class TestWasapiDownloaderSettings {
     assertEquals("accountId value should have come from settings file", settings.accountId(), "1");
     assertEquals("outputBaseDir value should have come from settings file", settings.outputBaseDir(), "test/outputBaseDir/");
     assertEquals("checksumAlgorithm value should have come from settings file", settings.checksumAlgorithm(), "md5");
+    assertEquals("retries value should have come from settings file", settings.retries(), "3");
+
     assertEquals("collectionId value should have come from args", settings.collectionId(), "123");
     assertEquals("crawlId value should have come from args", settings.crawlId(), "456");
     assertEquals("crawlStartAfter value should have come from args", settings.crawlStartAfter(), "2014-03-14");
@@ -44,7 +46,7 @@ public class TestWasapiDownloaderSettings {
   }
 
   @Test
-  @SuppressWarnings({"checkstyle:NoWhitespaceAfter", "checkstyle:MethodLength"})
+  @SuppressWarnings({"checkstyle:NoWhitespaceAfter", "checkstyle:MethodLength", "checkstyle:ExecutableStatementCount"})
   public void getHelpAndSettingsMessage_containsUsageAndSettingsInfo() throws SettingsLoadException {
     //TODO: if settings validation flags possibly nonsensical/redundant combos like crawlId and crawlIdLowerBound,
     // then this test might have to be broken up a bit.
@@ -69,6 +71,7 @@ public class TestWasapiDownloaderSettings {
     assertThat("helpAndSettingsMsg lists filename arg", helpAndSettingsMsg, containsString("--filename <arg>"));
     assertThat("helpAndSettingsMsg lists help flag", helpAndSettingsMsg, containsString("-h,--help"));
     assertThat("helpAndSettingsMsg lists password arg", helpAndSettingsMsg, containsString("--password <arg>"));
+    assertThat("helpAndSettingsMsg lists retries arg", helpAndSettingsMsg, containsString("--retries <arg>"));
     assertThat("helpAndSettingsMsg lists username arg", helpAndSettingsMsg, containsString("--username <arg>"));
 
     // values
@@ -84,6 +87,7 @@ public class TestWasapiDownloaderSettings {
     assertThat("helpAndSettingsMsg lists filename value", helpAndSettingsMsg, containsString("filename : filename.warc.gz"));
     assertThat("helpAndSettingsMsg lists help flag value", helpAndSettingsMsg, containsString("help : true"));
     assertThat("helpAndSettingsMsg hides password value", helpAndSettingsMsg, containsString("password : [password hidden]"));
+    assertThat("helpAndSettingsMsg lists retries value", helpAndSettingsMsg, containsString("retries : 3"));
     assertThat("helpAndSettingsMsg lists username value", helpAndSettingsMsg, containsString("username : user"));
   }
 
@@ -157,6 +161,7 @@ public class TestWasapiDownloaderSettings {
     internalSettings.setProperty(WasapiDownloaderSettings.CRAWL_START_BEFORE_PARAM_NAME, "01/01/2001");
     internalSettings.setProperty(WasapiDownloaderSettings.OUTPUT_BASE_DIR_PARAM_NAME, "does/not/exist");
     internalSettings.setProperty(WasapiDownloaderSettings.PASSWORD_PARAM_NAME, "");
+    internalSettings.setProperty(WasapiDownloaderSettings.RETRIES_PARAM_NAME, "-1");
     internalSettings.setProperty(WasapiDownloaderSettings.USERNAME_PARAM_NAME, "");
 
     List<String> errMsgs = wdSettings.getSettingsErrorMessages();
@@ -171,6 +176,7 @@ public class TestWasapiDownloaderSettings {
     assertThat("error messages has entry for invalid crawlStartBefore", errMsgs, hasItem("crawlStartBefore must be a valid ISO 8601 date string (if specified)"));
     assertThat("error messages has entry for invalid outputBaseDir", errMsgs, hasItem("outputBaseDir is required (and must be an extant, writable directory)"));
     assertThat("error messages has entry for invalid password", errMsgs, hasItem("password is required"));
+    assertThat("error messages has entry for invalid retries", errMsgs, hasItem("retries is required and must be an integer >= 0"));
     assertThat("error messages has entry for invalid username", errMsgs, hasItem("username is required"));
   }
 

--- a/test/edu/stanford/dlss/was/TestWasapiDownloader_DownloadAndValidateFile.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloader_DownloadAndValidateFile.java
@@ -128,7 +128,7 @@ public class TestWasapiDownloader_DownloadAndValidateFile {
     Mockito.doReturn(true).when(downloaderSpy).checksumValidate(defaultSettings().checksumAlgorithm(), wfile, fullFilePath);
 
     downloaderSpy.downloadAndValidateFile(wfile);
-    verify(mockConn, times(WasapiDownloader.NUM_RETRIES + 1)).downloadQuery(firstLocation, fullFilePath);
+    verify(mockConn, times(defaultNumRetries() + 1)).downloadQuery(firstLocation, fullFilePath);
     verify(downloaderSpy, times(1)).checksumValidate(defaultSettings().checksumAlgorithm(), wfile, fullFilePath);
   }
 
@@ -149,8 +149,8 @@ public class TestWasapiDownloader_DownloadAndValidateFile {
     Mockito.doReturn(false, false, false, true).when(downloaderSpy).checksumValidate(defaultSettings().checksumAlgorithm(), wfile, fullFilePath);
 
     downloaderSpy.downloadAndValidateFile(wfile);
-    verify(mockConn, times(WasapiDownloader.NUM_RETRIES + 1)).downloadQuery(firstLocation, fullFilePath);
-    verify(downloaderSpy, times(WasapiDownloader.NUM_RETRIES + 1)).checksumValidate(defaultSettings().checksumAlgorithm(), wfile, fullFilePath);
+    verify(mockConn, times(defaultNumRetries() + 1)).downloadQuery(firstLocation, fullFilePath);
+    verify(downloaderSpy, times(defaultNumRetries() + 1)).checksumValidate(defaultSettings().checksumAlgorithm(), wfile, fullFilePath);
   }
 
   @Test
@@ -194,7 +194,7 @@ public class TestWasapiDownloader_DownloadAndValidateFile {
     System.setErr(new PrintStream(errContent));
 
     downloaderSpy.downloadAndValidateFile(wfile);
-    verify(mockConn, times(WasapiDownloader.NUM_RETRIES + 1)).downloadQuery(firstLocation, fullFilePath);
+    verify(mockConn, times(defaultNumRetries() + 1)).downloadQuery(firstLocation, fullFilePath);
     verify(downloaderSpy, never()).checksumValidate(defaultSettings().checksumAlgorithm(), wfile, fullFilePath);
     assertEquals("Wrong SYSERR output", "file not retrieved or unable to validate checksum: " + firstLocation + "\n", errContent.toString());
   }
@@ -219,8 +219,8 @@ public class TestWasapiDownloader_DownloadAndValidateFile {
     System.setErr(new PrintStream(errContent));
 
     downloaderSpy.downloadAndValidateFile(wfile);
-    verify(mockConn, times(WasapiDownloader.NUM_RETRIES + 1)).downloadQuery(firstLocation, fullFilePath);
-    verify(downloaderSpy, times(WasapiDownloader.NUM_RETRIES + 1)).checksumValidate(defaultSettings().checksumAlgorithm(), wfile, fullFilePath);
+    verify(mockConn, times(defaultNumRetries() + 1)).downloadQuery(firstLocation, fullFilePath);
+    verify(downloaderSpy, times(defaultNumRetries() + 1)).checksumValidate(defaultSettings().checksumAlgorithm(), wfile, fullFilePath);
     assertEquals("Wrong SYSERR output", "file not retrieved or unable to validate checksum: " + firstLocation + "\n", errContent.toString());
   }
 
@@ -299,7 +299,7 @@ public class TestWasapiDownloader_DownloadAndValidateFile {
     System.setErr(new PrintStream(errContent));
 
     downloaderSpy.downloadAndValidateFile(wfile);
-    verify(mockConn, times(WasapiDownloader.NUM_RETRIES + 1)).downloadQuery(firstLocation, fullFilePath);
+    verify(mockConn, times(defaultNumRetries() + 1)).downloadQuery(firstLocation, fullFilePath);
     verify(downloaderSpy, never()).checksumValidate(defaultSettings().checksumAlgorithm(), wfile, fullFilePath);
     String expected = "WARNING: exception downloading file (will retry): " + firstLocation;
     assertThat("SYSERR should indicate IOException", errContent.toString(), StringStartsWith.startsWith(expected));
@@ -308,5 +308,9 @@ public class TestWasapiDownloader_DownloadAndValidateFile {
 
   private WasapiDownloaderSettings defaultSettings() throws SettingsLoadException {
     return new WasapiDownloaderSettings(WasapiDownloader.SETTINGS_FILE_LOCATION, null);
+  }
+
+  private int defaultNumRetries() throws NumberFormatException, SettingsLoadException {
+    return Integer.valueOf(defaultSettings().retries());
   }
 }

--- a/test/edu/stanford/dlss/was/TestWasapiDownloader_PowerMock.java
+++ b/test/edu/stanford/dlss/was/TestWasapiDownloader_PowerMock.java
@@ -38,7 +38,8 @@ public class TestWasapiDownloader_PowerMock {
 
   @Test
   public void main_executesFileSetRequest_usesAllAppropArgsSettings() throws Exception {
-    String[] args = {"--collectionId", "123", "--jobId=456", "--crawlStartAfter", "2014-03-14", "--crawlStartBefore=2017-03-14", "--username=Fred" };
+    String[] args = {"--collectionId", "123", "--crawlId=456",
+        "--crawlStartAfter", "2014-03-14", "--crawlStartBefore=2017-03-14", "--username=Fred" };
     WasapiConnection mockConn = Mockito.mock(WasapiConnection.class);
     Mockito.when(mockConn.pagedJsonQuery(anyString())).thenReturn(null);
     WasapiDownloader downloaderSpy = PowerMockito.spy(new WasapiDownloader(WasapiDownloader.SETTINGS_FILE_LOCATION, args));
@@ -144,9 +145,9 @@ public class TestWasapiDownloader_PowerMock {
 
   @Test
   @SuppressWarnings("checkstyle:NoWhitespaceAfter")
-  public void downloadSelectedWarcs_byJobIdLowerBound() throws Exception {
+  public void downloadSelectedWarcs_byCrawlIdLowerBound() throws Exception {
     String argValue = "666";
-    String[] args = { "--jobIdLowerBound=" + argValue };
+    String[] args = { "--crawlIdLowerBound=" + argValue };
 
     WasapiCrawlSelector mockCrawlSelector = PowerMockito.mock(WasapiCrawlSelector.class);
     List<WasapiResponse> wasapiRespList = getWasapiRespList();


### PR DESCRIPTION
user facing:
- add setting for "retries" - ```how many times to retry a download for each file (retries + 1 = total tries)``` ( Connects to #93 )
- params rename to crawlId and crawlIdLowerBound (was jobId)   for consistency with wasapi terminology  ( Resolves #98 )

tech debt:
- fix assertEquals so expected and actual args in right position ( resolves #101)
- max line length of 120 for better readability (don't worry about it for tests)
