### PR TITLE
Fixes #120 (out of memory computing checksum of huge files)

### DIFF
--- a/src/edu/stanford/dlss/was/WasapiValidator.java
+++ b/src/edu/stanford/dlss/was/WasapiValidator.java
@@ -1,6 +1,7 @@
 package edu.stanford.dlss.was;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -53,9 +54,45 @@ public class WasapiValidator {
       throws NoSuchAlgorithmException, IOException {
     Path path = Paths.get(filePath);
     MessageDigest digest = MessageDigest.getInstance(algorithm);
-    byte[] computedChecksumBytes = digest.digest(Files.readAllBytes(path));
+    InputStream inputStream = Files.newInputStream(path);
+    checksumInputStream(digest, inputStream);
+    byte[] computedChecksumBytes = digest.digest();
     String computedChecksumString = bytesToHex(computedChecksumBytes);
     return expectedChecksum.toLowerCase().compareTo(computedChecksumString) == 0;
   }
+
+  /**
+    * @param digest
+    *         A {@link MessageDigest} instance.
+    * @param inputStream
+    *         An open input stream to update the digest with.
+    * @throws IOException
+    *         If an error occurs while reading from the input stream.
+    */
+  private static void checksumInputStream(MessageDigest digest, InputStream inputStream)
+      throws IOException {
+    byte[] buffer = new byte[MESSAGEDIGEST_BUFFER_LENGTH];
+    int n = 0;
+    boolean success = false;
+    try {
+      while (n != -1) {
+        n = inputStream.read(buffer);
+        if (n > 0) {
+          digest.update(buffer, 0, n);
+        }
+      }
+      success = true;
+    } finally {
+      // Don't mask an exception with another caused by close()
+      if (success) {
+        inputStream.close();
+      }
+    }
+  }
+
+  /**
+    * @see {link #checksumInputStream(MessageDigest, InputStreeam)}
+    */
+  private static final int MESSAGEDIGEST_BUFFER_LENGTH = 8192;
 
 }


### PR DESCRIPTION
It took me a couple of tries to get the correct unit test, cheskStyle, etc. right but here we are, computing the checksum incrementally instead of loading (e.g.) 2.2 GB into a byte array first.