### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -3,4 +3,3 @@ server 'was-downloader-dev.stanford.edu', user: 'was', roles: 'app'
 set :bundle_without, 'deployment'
 
 # allow ssh to host
-Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -3,4 +3,3 @@ server 'was-downloader.stanford.edu', user: 'was', roles: 'app'
 set :bundle_without, 'deployment'
 
 # allow ssh to host
-Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -3,4 +3,3 @@ server 'was-downloader-stage.stanford.edu', user: 'was', roles: 'app'
 set :bundle_without, 'deployment'
 
 # allow ssh to host
-Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.